### PR TITLE
feat(security): add configurable auto-lock with immediate logout

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -40,6 +40,8 @@ kotlin {
             implementation(libs.sqlcipher)
             implementation(libs.argon2)
             implementation(libs.security.crypto)
+            implementation(libs.androidx.datastore)
+            implementation(libs.androidx.lifecycle.process)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/CycleWiseApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/CycleWiseApp.kt
@@ -1,18 +1,108 @@
 package com.veleda.cyclewise
 
 import android.app.Application
+import android.content.SharedPreferences
+import android.os.SystemClock
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.veleda.cyclewise.di.appModule
+import com.veleda.cyclewise.settings.AppSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import androidx.core.content.edit
+import com.veleda.cyclewise.session.SessionBus
 
-class CycleWiseApp : Application() {
+class CycleWiseApp :
+    Application(),
+    LifecycleEventObserver,
+    KoinComponent {
+
+    private lateinit var prefs: SharedPreferences
+    private val appSettings: AppSettings by inject()
+    private val sessionBus: SessionBus by inject()
+
+    // Background scope to keep an autolock cache fresh
+    private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // Default if settings not available yet
+    @Volatile
+    private var autolockMinutesCache: Int = 10
+
     override fun onCreate() {
         super.onCreate()
+
         startKoin {
             printLogger()
             androidContext(this@CycleWiseApp)
             modules(appModule)
             allowOverride(false)
         }
+
+        prefs = getSharedPreferences("autolock_prefs", MODE_PRIVATE)
+
+        // Keep a live cache of the autolock minutes (avoids blocking on foreground)
+        appScope.launch {
+            appSettings.autolockMinutes.collectLatest { minutes ->
+                autolockMinutesCache = minutes
+            }
+        }
+
+        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+    }
+
+    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+        when (event) {
+            Lifecycle.Event.ON_STOP -> {
+                // App moved to background — remember when
+                prefs.edit {
+                    putLong(KEY_LAST_BG_AT_ELAPSED, SystemClock.elapsedRealtime())
+                }
+            }
+            Lifecycle.Event.ON_START -> {
+                // App returned to foreground — decide if we must lock immediately
+                val minutes = autolockMinutesCache
+                val last = prefs.getLong(KEY_LAST_BG_AT_ELAPSED, -1L)
+
+                if (shouldLockNow(minutes, last)) {
+                    // Close session scope to lock DB + clear session-scoped VMs
+                    getKoin().getScopeOrNull(SESSION_SCOPE_ID)?.close()
+
+                    // Hardening: clear the timestamp to avoid loop/stale values
+                    prefs.edit { remove(KEY_LAST_BG_AT_ELAPSED) }
+
+                    // Notify UI to navigate to login immediately
+                    sessionBus.emitLogout()
+                }
+            }
+            else -> Unit
+        }
+    }
+
+    /**
+     * Hardening rules:
+     * - minutes == 0  -> always lock on foreground
+     * - no last value -> don't lock (unless minutes == 0)
+     * - elapsed >= minutes -> lock
+     */
+    private fun shouldLockNow(minutes: Int, lastBgAtElapsed: Long): Boolean {
+        if (minutes == 0) return true
+        if (lastBgAtElapsed <= 0L) return false
+        val elapsedMs = SystemClock.elapsedRealtime() - lastBgAtElapsed
+        val thresholdMs = minutes * 60_000L
+        return elapsedMs >= thresholdMs
+    }
+
+    companion object {
+        private const val KEY_LAST_BG_AT_ELAPSED = "last_bg_at_elapsed"
+        private const val SESSION_SCOPE_ID = "session"
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
@@ -13,9 +13,11 @@ import com.veleda.cyclewise.services.PassphraseServiceAndroid
 import com.veleda.cyclewise.androidData.local.database.CycleDatabase
 import com.veleda.cyclewise.androidData.repository.RoomCycleRepository
 import com.veleda.cyclewise.domain.usecases.EndCycleUseCase
+import com.veleda.cyclewise.settings.AppSettings
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.core.scope.Scope
+import com.veleda.cyclewise.session.SessionBus
 
 val SESSION_SCOPE = named("UnlockedSessionScope")
 
@@ -25,6 +27,12 @@ val appModule = module {
 
     // KDF: Argon2 passphrase service
     single<PassphraseService> { PassphraseServiceAndroid(get()) }
+
+    // App scoped settings
+    single { AppSettings(androidContext()) }
+
+    // Event bus for logout/navigation signals
+    single { SessionBus() }
 
     // Session-scoped SQLCipher DB and related services
     scope(SESSION_SCOPE) {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/session/SessionBus.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/session/SessionBus.kt
@@ -1,0 +1,22 @@
+package com.veleda.cyclewise.session
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Tiny event bus for session-level signals (e.g., logout).
+ * Keeps UI decoupled from lifecycle observers and DI internals.
+ */
+class SessionBus {
+    private val _logout = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val logout: SharedFlow<Unit> = _logout
+
+    fun emitLogout() {
+        _logout.tryEmit(Unit)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
@@ -1,0 +1,17 @@
+package com.veleda.cyclewise.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore by preferencesDataStore("app_settings")
+private val AUTOLOCK_MIN = intPreferencesKey("autolock_min")
+
+class AppSettings(private val context: Context) {
+    val autolockMinutes = context.dataStore.data.map { prefs -> prefs[AUTOLOCK_MIN] ?: 10 }
+    suspend fun setAutolockMinutes(min: Int) {
+        context.dataStore.edit { it[AUTOLOCK_MIN] = min }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
@@ -17,13 +17,30 @@ import com.veleda.cyclewise.ui.nav.*
 import com.veleda.cyclewise.ui.tracker.TrackerScreen
 import com.veleda.cyclewise.ui.auth.PassphraseScreen
 import androidx.compose.runtime.getValue
+import com.veleda.cyclewise.ui.settings.SettingsScreen
+import androidx.compose.runtime.LaunchedEffect
+import androidx.navigation.compose.rememberNavController
+import com.veleda.cyclewise.session.SessionBus
+import org.koin.compose.koinInject
 
 @Composable
 @Preview
 fun CycleWiseAppUI() {
     val navController = rememberNavController()
+    val sessionBus: SessionBus = koinInject()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
+
+    LaunchedEffect(Unit) {
+        sessionBus.logout.collect {
+            // Clear back stack and go to Passphrase screen
+            navController.navigate(NavRoute.Passphrase.route) {
+                popUpTo(0) { inclusive = true }
+                launchSingleTop = true
+                restoreState = false
+            }
+        }
+    }
 
     Scaffold(
         bottomBar = {
@@ -53,7 +70,7 @@ fun CycleWiseAppUI() {
             }
             // 3) Settings placeholder
             composable(NavRoute.Settings.route) {
-                Text("Settings screen coming soon")
+                SettingsScreen(navController)
             }
 
             composable(NavRoute.Hello.route) {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
@@ -1,0 +1,78 @@
+package com.veleda.cyclewise.ui.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.veleda.cyclewise.ui.nav.NavRoute
+import com.veleda.cyclewise.settings.AppSettings
+import kotlinx.coroutines.launch
+import org.koin.java.KoinJavaComponent.getKoin
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(navController: NavController) {
+    // App settings are app-scoped (available even when locked)
+    val appSettings: AppSettings = getKoin().get()
+    val autolock by appSettings.autolockMinutes.collectAsState(initial = 10)
+    val scope = rememberCoroutineScope()
+
+    // Session scope (only present when unlocked)
+    val session = getKoin().getScopeOrNull("session")
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Settings") }) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            // Auto-lock timeout
+            Text("Auto-lock timeout (minutes)", style = MaterialTheme.typography.titleMedium)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(5, 10, 15, 30).forEach { m ->
+                    FilterChip(
+                        selected = autolock == m,
+                        onClick = { scope.launch { appSettings.setAutolockMinutes(m) } },
+                        label = { Text("$m") }
+                    )
+                    Spacer(Modifier.width(4.dp))
+                }
+            }
+
+            // Lock Now (only if there’s an unlocked session)
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text("Security", style = MaterialTheme.typography.titleMedium)
+                Spacer(Modifier.height(8.dp))
+                Button(
+                    enabled = session != null,
+                    onClick = {
+                        // Close the unlocked session and bounce to Passphrase
+                        session?.close()
+                        navController.navigate(NavRoute.Passphrase.route) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    }
+                ) {
+                    Text("Lock Now")
+                }
+                if (session == null) {
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        "Currently locked — unlock to access secured data.",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ koin = "4.1.0"
 room = "2.7.2"
 sqlcipher = "4.5.4"
 security_crypto = "1.1.0"
+datastore = "1.1.7"
+lifecycle = "2.9.2"
 
 [libraries]
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleViewmodelKtx" }
@@ -36,6 +38,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle"}
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktorVersion" }
@@ -55,6 +58,7 @@ room-compiler= { module = "androidx.room:room-compiler",version.ref = "room" }
 sqlcipher    = { module = "net.zetetic:android-database-sqlcipher", version.ref = "sqlcipher" }
 argon2 = { module = "org.bouncycastle:bcpkix-jdk15on", version = "1.70" }
 security-crypto = { module = "androidx.security:security-crypto", version.ref = "security_crypto" }
+androidx-datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Add AppSettings backed by DataStore for storing auto-lock timeout (minutes)
- Implement ProcessLifecycleOwner observer in CycleWiseApp to: • Record last background time • Check elapsed time on foreground • Close session scope and emit logout if timeout exceeded • Support “always lock” when timeout is 0 • Clear stored timestamp on logout to prevent stale triggers
- Introduce SessionBus SharedFlow to broadcast logout events to UI
- Update CycleWiseAppUI to collect logout events and navigate instantly to Passphrase screen
- Add SettingsScreen for: • Selecting auto-lock timeout (5/10/15/30 minutes) • Manual “Lock Now” action that closes session and returns to Passphrase
- Wire AppSettings and SessionBus into appModule as app-scoped singletons
- Add lifecycle-process and datastore dependencies

BREAKING CHANGE:
- Session timeout handling is now centralized in CycleWiseApp with SessionBus events; any prior ad-hoc timeout checks should be removed.