### PR TITLE
feat(insights,ui,di,repo,nav,tests): introduce Insights Engine and sc…

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/MedicationLogDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/MedicationLogDao.kt
@@ -20,4 +20,7 @@ interface MedicationLogDao {
 
     @Query("DELETE FROM medication_logs WHERE entry_id = :dailyEntryId")
     suspend fun deleteLogsForEntry(dailyEntryId: String)
+
+    @Query("SELECT * FROM medication_logs")
+    fun getAllMedicationLogs(): Flow<List<MedicationLogEntity>>
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/SymptomLogDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/SymptomLogDao.kt
@@ -17,4 +17,7 @@ interface SymptomLogDao {
 
     @Query("DELETE FROM symptom_logs WHERE entry_id = :dailyEntryId")
     suspend fun deleteLogsForEntry(dailyEntryId: String)
+
+    @Query("SELECT * FROM symptom_logs")
+    fun getAllSymptomLogs(): Flow<List<SymptomLogEntity>>
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomCycleRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomCycleRepository.kt
@@ -14,6 +14,8 @@ import com.veleda.cyclewise.androidData.local.entities.toEntity
 import com.veleda.cyclewise.domain.models.Cycle
 import com.veleda.cyclewise.domain.models.DailyEntry
 import com.veleda.cyclewise.domain.models.FlowIntensity
+import com.veleda.cyclewise.domain.models.MedicationLog
+import com.veleda.cyclewise.domain.models.SymptomLog
 import com.veleda.cyclewise.domain.models.FullDailyLog
 import com.veleda.cyclewise.domain.models.Medication
 import com.veleda.cyclewise.domain.models.Symptom
@@ -314,5 +316,13 @@ class RoomCycleRepository(
             }
             detailsMap
         }
+    }
+
+    override suspend fun getAllSymptomLogs(): List<SymptomLog> {
+        return symptomLogDao.getAllSymptomLogs().first().map { it.toDomain() }
+    }
+
+    override suspend fun getAllMedicationLogs(): List<MedicationLog> {
+        return medicationLogDao.getAllMedicationLogs().first().map { it.toDomain() }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
@@ -12,6 +12,7 @@ import com.veleda.cyclewise.domain.services.PassphraseService
 import com.veleda.cyclewise.services.PassphraseServiceAndroid
 import com.veleda.cyclewise.androidData.local.database.CycleDatabase
 import com.veleda.cyclewise.androidData.repository.RoomCycleRepository
+import com.veleda.cyclewise.domain.insights.InsightEngine
 import com.veleda.cyclewise.domain.providers.MedicationLibraryProvider
 import com.veleda.cyclewise.domain.providers.SymptomLibraryProvider
 import com.veleda.cyclewise.domain.usecases.EndCycleUseCase
@@ -21,6 +22,7 @@ import com.veleda.cyclewise.session.SessionBus
 import com.veleda.cyclewise.ui.log.DailyLogViewModel
 import com.veleda.cyclewise.settings.AppSettings
 import com.veleda.cyclewise.ui.auth.PassphraseViewModel
+import com.veleda.cyclewise.ui.insights.InsightsViewModel
 import org.koin.dsl.module
 import org.koin.core.scope.Scope
 import kotlinx.datetime.LocalDate
@@ -38,6 +40,8 @@ val appModule = module {
 
     // KDF: Argon2 passphrase service
     single<PassphraseService> { PassphraseServiceAndroid(get()) }
+
+    factory { InsightEngine() }
 
     // PassphraseViewModel here, outside of any scope
     viewModel { PassphraseViewModel(appSettings = get()) }
@@ -93,6 +97,13 @@ val appModule = module {
                 cycleRepository = get(),
                 symptomLibraryProvider = get(),
                 medicationLibraryProvider = get()
+            )
+        }
+
+        viewModel {
+            InsightsViewModel(
+                cycleRepository = get(),
+                insightEngine = get()
             )
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
@@ -17,6 +17,7 @@ import com.veleda.cyclewise.ui.nav.*
 import com.veleda.cyclewise.ui.tracker.TrackerScreen
 import com.veleda.cyclewise.ui.auth.PassphraseScreen
 import androidx.compose.runtime.getValue
+import com.veleda.cyclewise.ui.insights.InsightsScreen
 import com.veleda.cyclewise.ui.log.DailyLogScreen
 import com.veleda.cyclewise.ui.settings.SettingsScreen
 import kotlinx.datetime.LocalDate
@@ -42,7 +43,6 @@ fun CycleWiseAppUI() {
             startDestination = NavRoute.Passphrase.route,
             modifier = Modifier.padding(padding)
         ) {
-            // 1) Passphrase entry
             composable(NavRoute.Passphrase.route) {
                 PassphraseScreen {
                     navController.navigate(NavRoute.Tracker.route) {
@@ -50,17 +50,14 @@ fun CycleWiseAppUI() {
                     }
                 }
             }
-            // 2) Tracker
             composable(NavRoute.Tracker.route) {
                 TrackerScreen(navController)
             }
-            // 3) Settings placeholder
+            composable(NavRoute.Insights.route) {
+                InsightsScreen()
+            }
             composable(NavRoute.Settings.route) {
                 SettingsScreen(navController)
-            }
-
-            composable(NavRoute.Hello.route) {
-                Text("Hello!")
             }
 
             composable(

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsScreen.kt
@@ -1,0 +1,79 @@
+package com.veleda.cyclewise.ui.insights
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.veleda.cyclewise.domain.insights.Insight
+import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.getKoin
+import org.koin.compose.koinInject
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InsightsScreen() {
+    val viewModel: InsightsViewModel = koinViewModel(scope = getKoin().getScope("session"))
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Insights") })
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            } else if (uiState.insights.isEmpty()) {
+                Text(
+                    text = "Not enough data to generate insights yet. Keep tracking!",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(horizontal = 16.dp)
+                )
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(uiState.insights, key = { it.title }) { insight ->
+                        InsightCard(insight = insight)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InsightCard(insight: Insight) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = insight.title,
+                style = MaterialTheme.typography.titleLarge
+            )
+            Text(
+                text = insight.description,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModel.kt
@@ -1,0 +1,57 @@
+package com.veleda.cyclewise.ui.insights
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.veleda.cyclewise.domain.insights.Insight
+import com.veleda.cyclewise.domain.insights.InsightEngine
+import com.veleda.cyclewise.domain.repository.CycleRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class InsightsUiState(
+    val isLoading: Boolean = true,
+    val insights: List<Insight> = emptyList()
+)
+
+class InsightsViewModel(
+    private val cycleRepository: CycleRepository,
+    private val insightEngine: InsightEngine
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(InsightsUiState())
+    val uiState: StateFlow<InsightsUiState> = _uiState.asStateFlow()
+
+    init {
+        generateInsights()
+    }
+
+    private fun generateInsights() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+
+            // Fetch all necessary data in one go
+            val allCycles = cycleRepository.getAllCycles().first()
+            val allSymptomLogs = cycleRepository.getAllSymptomLogs()
+            val symptomLibrary = cycleRepository.getSymptomLibrary().first()
+
+            // Run the analysis
+            val generatedInsights = insightEngine.generateInsights(
+                allCycles = allCycles,
+                allSymptomLogs = allSymptomLogs,
+                symptomLibrary = symptomLibrary
+            )
+
+            // Update the state with the results
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    insights = generatedInsights
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/nav/BottomNavBar.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/nav/BottomNavBar.kt
@@ -19,8 +19,8 @@ fun BottomNavBar(navController: NavController) {
                 icon = {
                     Icon(
                         imageVector = when (route) {
-                            NavRoute.Hello ->  Icons.Default.Face
                             NavRoute.Tracker -> Icons.Default.DateRange
+                            NavRoute.Insights -> Icons.Default.Info
                             NavRoute.Settings -> Icons.Default.Settings
                             else -> error("Unexpected route in BottomNavBar: ${route.route}")
                         },

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/nav/NavRoutes.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/nav/NavRoutes.kt
@@ -3,17 +3,18 @@ package com.veleda.cyclewise.ui.nav
 import kotlinx.datetime.LocalDate
 
 sealed class NavRoute(val route: String, val label: String) {
-    object Hello : NavRoute("hello", "Hello")
-
     object Passphrase : NavRoute("passphrase", "Pass Phrase")
     object Tracker : NavRoute("tracker", "Tracker")
+    object Insights : NavRoute("insights", "Insights")
     object Settings : NavRoute("settings", "Settings")
-
     object DailyLog : NavRoute("log/{date}", "Daily Log") {
         fun createRoute(date: LocalDate) = "log/$date"
     }
 
     companion object {
-        val all = listOf(Hello, Tracker, Settings)
+        val all = listOf(
+            Tracker,
+            Insights,
+            Settings)
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/androidData/repository/RoomCycleRepositoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/androidData/repository/RoomCycleRepositoryTest.kt
@@ -220,4 +220,45 @@ class RoomCycleRepositoryTest : KoinTest {
         // ASSERT
         assertFalse(isAvailable)
     }
+
+    @Test
+    fun getAllSymptomLogs_WHEN_logsExist_THEN_returnsAllLogsFromAllCycles() = runTest {
+        // ARRANGE
+        // Create two separate cycles and entries
+        val cycle1 = repository.startNewCycle(LocalDate(2025, 1, 1))
+        val cycle2 = repository.createCompletedCycle(LocalDate(2025, 2, 1), LocalDate(2025, 2, 28))
+        val symptom1 = repository.createOrGetSymptomInLibrary("Headache", SymptomCategory.PAIN)
+
+        val log1 = FullDailyLog(DailyEntry("entry-1", cycle1.id, LocalDate(2025, 1, 5), 5, createdAt = Clock.System.now(), updatedAt = Clock.System.now()), symptomLogs = listOf(SymptomLog("slog-1", "entry-1", symptom1.id, 3, Clock.System.now())))
+        val log2 = FullDailyLog(DailyEntry("entry-2", cycle2.id, LocalDate(2025, 2, 5), 5, createdAt = Clock.System.now(), updatedAt = Clock.System.now()), symptomLogs = listOf(SymptomLog("slog-2", "entry-2", symptom1.id, 4, Clock.System.now())))
+        val log3WithNoSymptoms = FullDailyLog(DailyEntry("entry-3", cycle2.id, LocalDate(2025, 2, 6), 6, createdAt = Clock.System.now(), updatedAt = Clock.System.now()))
+        repository.saveFullLog(log1)
+        repository.saveFullLog(log2)
+        repository.saveFullLog(log3WithNoSymptoms)
+
+        // ACT
+        val allLogs = repository.getAllSymptomLogs()
+
+        // ASSERT
+        assertEquals(2, allLogs.size, "Should fetch all symptom logs regardless of cycle")
+        assertTrue(allLogs.any { it.id == "slog-1" })
+        assertTrue(allLogs.any { it.id == "slog-2" })
+    }
+
+    @Test
+    fun getAllMedicationLogs_WHEN_logsExist_THEN_returnsAllLogs() = runTest {
+        // ARRANGE
+        val cycle1 = repository.startNewCycle(LocalDate(2025, 1, 1))
+        val med1 = repository.createOrGetMedicationInLibrary("Ibuprofen")
+
+        val log1 = FullDailyLog(DailyEntry("entry-1", cycle1.id, LocalDate(2025, 1, 5), 5, createdAt = Clock.System.now(), updatedAt = Clock.System.now()), medicationLogs = listOf(MedicationLog("mlog-1", "entry-1", med1.id, Clock.System.now())))
+        repository.saveFullLog(log1)
+
+        // ACT
+        val allLogs = repository.getAllMedicationLogs()
+
+        // ASSERT
+        assertEquals(1, allLogs.size)
+        assertEquals("mlog-1", allLogs.first().id)
+    }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModelTest.kt
@@ -1,0 +1,94 @@
+package com.veleda.cyclewise.ui.insights
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import app.cash.turbine.test
+import com.veleda.cyclewise.domain.insights.CycleLengthAverage
+import com.veleda.cyclewise.domain.insights.InsightEngine
+import com.veleda.cyclewise.domain.repository.CycleRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InsightsViewModelTest {
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var mockRepository: CycleRepository
+    private lateinit var mockInsightEngine: InsightEngine
+    // Note: The viewModel is not initialized here anymore.
+    private lateinit var viewModel: InsightsViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockRepository = mockk()
+        mockInsightEngine = mockk()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `init WHEN data is loaded successfully THEN uiState is updated with insights`() = runTest {
+        // ARRANGE
+        val fakeInsights = listOf(CycleLengthAverage(28.5))
+        coEvery { mockRepository.getAllCycles() } returns flowOf(emptyList())
+        coEvery { mockRepository.getAllSymptomLogs() } returns emptyList()
+        coEvery { mockRepository.getSymptomLibrary() } returns flowOf(emptyList())
+        coEvery { mockInsightEngine.generateInsights(any(), any(), any()) } returns fakeInsights
+
+        // ACT - Create the ViewModel *after* mocks are set up.
+        viewModel = InsightsViewModel(mockRepository, mockInsightEngine)
+
+        // ASSERT
+        viewModel.uiState.test {
+            // Because of the UnconfinedTestDispatcher, the init block has already finished.
+            // We are only observing the final state.
+            val finalState = awaitItem()
+            assertFalse(finalState.isLoading, "Final state should not be loading")
+            assertEquals(fakeInsights, finalState.insights)
+
+            // We expect no more emissions.
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `init WHEN engine returns no insights THEN uiState is updated with empty list`() = runTest {
+        // ARRANGE
+        coEvery { mockRepository.getAllCycles() } returns flowOf(emptyList())
+        coEvery { mockRepository.getAllSymptomLogs() } returns emptyList()
+        coEvery { mockRepository.getSymptomLibrary() } returns flowOf(emptyList())
+        coEvery { mockInsightEngine.generateInsights(any(), any(), any()) } returns emptyList()
+
+        // ACT
+        viewModel = InsightsViewModel(mockRepository, mockInsightEngine)
+
+        // ASSERT
+        viewModel.uiState.test {
+            val finalState = awaitItem()
+            assertFalse(finalState.isLoading)
+            assertTrue(finalState.insights.isEmpty())
+            expectNoEvents()
+        }
+    }
+}

--- a/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/insights/InsightEngineTest.kt
+++ b/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/insights/InsightEngineTest.kt
@@ -1,0 +1,98 @@
+package com.veleda.cyclewise.domain.insights
+
+import com.veleda.cyclewise.domain.models.Cycle
+import com.veleda.cyclewise.domain.models.Symptom
+import com.veleda.cyclewise.domain.models.SymptomCategory
+import com.veleda.cyclewise.domain.models.SymptomLog
+import kotlinx.datetime.LocalDate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+class InsightEngineTest {
+
+    private lateinit var insightEngine: InsightEngine
+
+    // --- Test Data ---
+    @OptIn(ExperimentalTime::class)
+    private val symptomLib = listOf(
+        Symptom("symptom-1", "Headache", SymptomCategory.PAIN, Clock.System.now()),
+        Symptom("symptom-2", "Cramps", SymptomCategory.PAIN, Clock.System.now())
+    )
+    @OptIn(ExperimentalTime::class)
+    private val symptomLogs = listOf(
+        SymptomLog("log-1", "entry-1", "symptom-1", 3, Clock.System.now()),
+        SymptomLog("log-2", "entry-2", "symptom-2", 4, Clock.System.now()),
+        SymptomLog("log-3", "entry-3", "symptom-1", 5, Clock.System.now()) // Headache is most common
+    )
+    @OptIn(ExperimentalTime::class)
+    private val cycles = listOf(
+        // Completed cycle of 28 days
+        Cycle("cycle-1", LocalDate(2025, 1, 1), LocalDate(2025, 1, 28), Clock.System.now(), Clock.System.now()),
+        // Completed cycle of 30 days
+        Cycle("cycle-2", LocalDate(2025, 1, 29), LocalDate(2025, 2, 27), Clock.System.now(), Clock.System.now()),
+        // Ongoing cycle, should be ignored by length calculation
+        Cycle("cycle-3", LocalDate(2025, 2, 28), null, Clock.System.now(), Clock.System.now())
+    )
+
+    @BeforeTest
+    fun setUp() {
+        insightEngine = InsightEngine()
+    }
+
+    @Test
+    fun generateInsights_WHEN_sufficientDataExists_THEN_returnsAllInsightsSortedByPriority() {
+        // ACT
+        val insights = insightEngine.generateInsights(cycles, symptomLogs, symptomLib)
+
+        // ASSERT
+        assertEquals(2, insights.size)
+        // Check sorting: CycleLengthAverage has priority 100, SymptomRecurrence has 90
+        assertTrue(insights[0] is CycleLengthAverage)
+        assertTrue(insights[1] is SymptomRecurrence)
+
+        val cycleInsight = insights[0] as CycleLengthAverage
+        assertEquals(29.0, cycleInsight.averageDays) // (28 + 30) / 2 = 29
+
+        val symptomInsight = insights[1] as SymptomRecurrence
+        assertEquals("Headache", symptomInsight.symptomName) // Headache appears twice
+    }
+
+    @Test
+    fun generateInsights_WHEN_insufficientCycles_THEN_omitsCycleLengthInsight() {
+        // ARRANGE: Only provide one completed cycle
+        val insufficientCycles = listOf(cycles.first())
+
+        // ACT
+        val insights = insightEngine.generateInsights(insufficientCycles, symptomLogs, symptomLib)
+
+        // ASSERT
+        assertEquals(1, insights.size)
+        assertTrue(insights.first() is SymptomRecurrence, "Should only generate symptom insight")
+    }
+
+    @Test
+    fun generateInsights_WHEN_noSymptomLogs_THEN_omitsSymptomRecurrenceInsight() {
+        // ARRANGE: Provide an empty list of logs
+        val noLogs = emptyList<SymptomLog>()
+
+        // ACT
+        val insights = insightEngine.generateInsights(cycles, noLogs, symptomLib)
+
+        // ASSERT
+        assertEquals(1, insights.size)
+        assertTrue(insights.first() is CycleLengthAverage, "Should only generate cycle length insight")
+    }
+
+    @Test
+    fun generateInsights_WHEN_noData_THEN_returnsEmptyList() {
+        // ACT
+        val insights = insightEngine.generateInsights(emptyList(), emptyList(), emptyList())
+
+        // ASSERT
+        assertTrue(insights.isEmpty(), "Expected no insights when no data is provided")
+    }
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
@@ -1,0 +1,38 @@
+package com.veleda.cyclewise.domain.insights
+
+import kotlin.math.floor
+import kotlin.math.roundToInt
+
+/**
+ * A sealed interface representing a single piece of generated insight
+ * derived from the user's health data.
+ */
+sealed interface Insight {
+    val title: String
+    val description: String
+    val priority: Int // Used for sorting; higher numbers are more important.
+}
+
+/**
+ * An insight about the user's average cycle length.
+ * @param averageDays The calculated average length of completed cycles.
+ */
+data class CycleLengthAverage(
+    val averageDays: Double
+) : Insight {
+    override val title: String = "Average Cycle Length"
+    override val description: String = "Based on your completed cycles, your average length is ${averageDays.roundToInt()} days."
+    override val priority: Int = 100
+}
+
+/**
+ * An insight identifying one of the most frequently logged symptoms.
+ * @param symptomName The name of the recurring symptom.
+ */
+data class SymptomRecurrence(
+    val symptomName: String
+) : Insight {
+    override val title: String = "Frequent Symptom"
+    override val description: String = "$symptomName is one of your most frequently logged symptoms."
+    override val priority: Int = 90
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/InsightEngine.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/InsightEngine.kt
@@ -1,0 +1,84 @@
+package com.veleda.cyclewise.domain.insights
+
+import com.veleda.cyclewise.domain.models.Cycle
+import com.veleda.cyclewise.domain.models.Symptom
+import com.veleda.cyclewise.domain.models.SymptomLog
+import kotlinx.datetime.daysUntil
+
+/**
+ * Analyzes user data to generate a list of actionable or interesting insights.
+ */
+class InsightEngine {
+
+    /**
+     * The primary function that orchestrates the generation of all available insights.
+     *
+     * @param allCycles A complete list of the user's cycles.
+     * @param allSymptomLogs A complete list of all symptom log entries.
+     * @param symptomLibrary The user's symptom library for name lookups.
+     * @return A list of generated `Insight` objects, sorted by priority.
+     */
+    fun generateInsights(
+        allCycles: List<Cycle>,
+        allSymptomLogs: List<SymptomLog>,
+        symptomLibrary: List<Symptom>
+    ): List<Insight> {
+        val insights = mutableListOf<Insight>()
+
+        // --- Generator 1: Cycle Length Average ---
+        generateCycleLengthAverage(allCycles)?.let { insights.add(it) }
+
+        // --- Generator 2: Symptom Recurrence ---
+        generateSymptomRecurrence(allSymptomLogs, symptomLibrary)?.let { insights.add(it) }
+
+        // Return all found insights, with the highest priority ones first.
+        return insights.sortedByDescending { it.priority }
+    }
+
+    /**
+     * Calculates the average length of a user's completed menstrual cycles.
+     * Requires at least two completed cycles to generate a meaningful average.
+     */
+    private fun generateCycleLengthAverage(allCycles: List<Cycle>): CycleLengthAverage? {
+        val completedCycles = allCycles.filter { it.endDate != null }
+
+        // We need at least two data points to calculate a meaningful average.
+        if (completedCycles.size < 2) {
+            return null
+        }
+
+        val average = completedCycles
+            .map { it.startDate.daysUntil(it.endDate!!) + 1 } // +1 to be inclusive
+            .average()
+
+        return CycleLengthAverage(average)
+    }
+
+    /**
+     * Identifies the symptom that has been logged most frequently by the user.
+     */
+    private fun generateSymptomRecurrence(
+        allSymptomLogs: List<SymptomLog>,
+        symptomLibrary: List<Symptom>
+    ): SymptomRecurrence? {
+        if (allSymptomLogs.isEmpty()) {
+            return null
+        }
+
+        // Group logs by symptomId and find the group with the largest size.
+        val mostFrequentEntry = allSymptomLogs
+            .groupBy { it.symptomId }
+            .maxByOrNull { it.value.size }
+
+        if (mostFrequentEntry == null) {
+            return null
+        }
+
+        // Look up the symptom's name from the library using its ID.
+        val symptomInfo = symptomLibrary.find { it.id == mostFrequentEntry.key }
+
+        return symptomInfo?.let {
+            SymptomRecurrence(symptomName = it.name)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/repository/CycleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/repository/CycleRepository.kt
@@ -5,8 +5,10 @@ import com.veleda.cyclewise.domain.models.DailyEntry
 import com.veleda.cyclewise.domain.models.DayDetails
 import com.veleda.cyclewise.domain.models.FullDailyLog
 import com.veleda.cyclewise.domain.models.Medication
+import com.veleda.cyclewise.domain.models.MedicationLog
 import com.veleda.cyclewise.domain.models.Symptom
 import com.veleda.cyclewise.domain.models.SymptomCategory
+import com.veleda.cyclewise.domain.models.SymptomLog
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.YearMonth
@@ -83,4 +85,10 @@ interface CycleRepository {
      * This is the single source of truth for the calendar UI.
      */
     fun observeDayDetails(): Flow<Map<LocalDate, DayDetails>>
+
+    /** Fetches a one-shot list of all symptom logs. */
+    suspend fun getAllSymptomLogs(): List<SymptomLog>
+
+    /** Fetches a one-shot list of all medication logs. */
+    suspend fun getAllMedicationLogs(): List<MedicationLog>
 }


### PR DESCRIPTION
feat(insights,ui,di,repo,nav,tests): introduce Insights Engine and screen

add domain insights module with InsightEngine and Insight models (CycleLengthAverage, SymptomRecurrence)

repository: expose getAllSymptomLogs/getAllMedicationLogs and implement via new DAO queries

di: bind InsightEngine as factory and register InsightsViewModel in session scope

ui: add InsightsScreen and card rendering; wire into CycleWiseAppUI navigation

nav: add NavRoute.Insights and bottom-nav icon; remove unused Hello route

tests: add InsightEngineTest, InsightsViewModelTest, and repository tests for new getters