### PR TITLE
feat(insights,tests): add next period start prediction

### DIFF
--- a/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/insights/InsightEngineTest.kt
+++ b/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/insights/InsightEngineTest.kt
@@ -28,14 +28,19 @@ class InsightEngineTest {
         SymptomLog("log-2", "entry-2", "symptom-2", 4, Clock.System.now()),
         SymptomLog("log-3", "entry-3", "symptom-1", 5, Clock.System.now()) // Headache is most common
     )
+
+    // Realistic test data. Periods are a few days long.
+    // List is sorted descending by start date, as it would be from the repository.
     @OptIn(ExperimentalTime::class)
     private val cycles = listOf(
-        // Completed cycle of 28 days
-        Cycle("cycle-1", LocalDate(2025, 1, 1), LocalDate(2025, 1, 28), Clock.System.now(), Clock.System.now()),
-        // Completed cycle of 30 days
-        Cycle("cycle-2", LocalDate(2025, 1, 29), LocalDate(2025, 2, 27), Clock.System.now(), Clock.System.now()),
-        // Ongoing cycle, should be ignored by length calculation
-        Cycle("cycle-3", LocalDate(2025, 2, 28), null, Clock.System.now(), Clock.System.now())
+        // Latest cycle (ongoing)
+        Cycle("cycle-4", LocalDate(2025, 3, 30), null, Clock.System.now(), Clock.System.now()),
+        // Completed cycle. Duration from start to next start = 30 days.
+        Cycle("cycle-3", LocalDate(2025, 2, 28), LocalDate(2025, 3, 4), Clock.System.now(), Clock.System.now()),
+        // Completed cycle. Duration from start to next start = 28 days.
+        Cycle("cycle-2", LocalDate(2025, 1, 31), LocalDate(2025, 2, 4), Clock.System.now(), Clock.System.now()),
+        // Completed cycle.
+        Cycle("cycle-1", LocalDate(2025, 1, 1), LocalDate(2025, 1, 5), Clock.System.now(), Clock.System.now())
     )
 
     @BeforeTest
@@ -49,29 +54,40 @@ class InsightEngineTest {
         val insights = insightEngine.generateInsights(cycles, symptomLogs, symptomLib)
 
         // ASSERT
-        assertEquals(2, insights.size)
-        // Check sorting: CycleLengthAverage has priority 100, SymptomRecurrence has 90
-        assertTrue(insights[0] is CycleLengthAverage)
-        assertTrue(insights[1] is SymptomRecurrence)
+        assertEquals(3, insights.size)
+        // Check sorting: Prediction (110), Average (100), Symptom (90)
+        assertTrue(insights[0] is NextPeriodPrediction)
+        assertTrue(insights[1] is CycleLengthAverage)
+        assertTrue(insights[2] is SymptomRecurrence)
 
-        val cycleInsight = insights[0] as CycleLengthAverage
-        assertEquals(29.0, cycleInsight.averageDays) // (28 + 30) / 2 = 29
+        // Test average cycle length calculation:
+        // Duration 1 = (Jan 29 - Jan 1) = 28 days.
+        // Duration 2 = (Feb 28 - Jan 29) = 30 days.
+        // Average = (28 + 30) / 2 = 29 days.
+        val cycleInsight = insights[1] as CycleLengthAverage
+        assertEquals(29.0, cycleInsight.averageDays)
 
-        val symptomInsight = insights[1] as SymptomRecurrence
-        assertEquals("Headache", symptomInsight.symptomName) // Headache appears twice
+        // Test period prediction calculation:
+        // Prediction = Start of last period (March 30) + 29 days = April 28.
+        val predictionInsight = insights[0] as NextPeriodPrediction
+        assertEquals(LocalDate(2025, 4, 28), predictionInsight.predictedDate)
     }
 
+    @OptIn(ExperimentalTime::class)
     @Test
-    fun generateInsights_WHEN_insufficientCycles_THEN_omitsCycleLengthInsight() {
-        // ARRANGE: Only provide one completed cycle
-        val insufficientCycles = listOf(cycles.first())
+    fun generateInsights_WHEN_notEnoughCompletedCycles_THEN_omitsPredictionAndAverageInsights() {
+        // ARRANGE: Only one completed cycle, which is not enough to calculate a duration.
+        val insufficientCycles = listOf(
+            Cycle("cycle-2", LocalDate(2025, 2, 1), null, Clock.System.now(), Clock.System.now()),
+            Cycle("cycle-1", LocalDate(2025, 1, 1), LocalDate(2025, 1, 5), Clock.System.now(), Clock.System.now())
+        )
 
         // ACT
         val insights = insightEngine.generateInsights(insufficientCycles, symptomLogs, symptomLib)
 
         // ASSERT
-        assertEquals(1, insights.size)
-        assertTrue(insights.first() is SymptomRecurrence, "Should only generate symptom insight")
+        assertEquals(1, insights.size, "Should only generate symptom insight, as cycle insights require at least two completed periods")
+        assertTrue(insights[0] is SymptomRecurrence)
     }
 
     @Test
@@ -83,8 +99,9 @@ class InsightEngineTest {
         val insights = insightEngine.generateInsights(cycles, noLogs, symptomLib)
 
         // ASSERT
-        assertEquals(1, insights.size)
-        assertTrue(insights.first() is CycleLengthAverage, "Should only generate cycle length insight")
+        assertEquals(2, insights.size)
+        assertTrue(insights.any { it is NextPeriodPrediction }, "Should generate prediction insight")
+        assertTrue(insights.any { it is CycleLengthAverage }, "Should generate cycle length insight")
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
@@ -1,5 +1,6 @@
 package com.veleda.cyclewise.domain.insights
 
+import kotlinx.datetime.LocalDate
 import kotlin.math.floor
 import kotlin.math.roundToInt
 
@@ -35,4 +36,16 @@ data class SymptomRecurrence(
     override val title: String = "Frequent Symptom"
     override val description: String = "$symptomName is one of your most frequently logged symptoms."
     override val priority: Int = 90
+}
+
+/**
+ * An insight that predicts the start date of the next menstrual period.
+ * @param predictedDate The calculated date for the next period's start.
+ */
+data class NextPeriodPrediction(
+    val predictedDate: LocalDate
+) : Insight {
+    override val title: String = "Next Period Forecast"
+    override val description: String = "Your next period is predicted to start on or around $predictedDate."
+    override val priority: Int = 110
 }

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/InsightEngine.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/InsightEngine.kt
@@ -3,7 +3,11 @@ package com.veleda.cyclewise.domain.insights
 import com.veleda.cyclewise.domain.models.Cycle
 import com.veleda.cyclewise.domain.models.Symptom
 import com.veleda.cyclewise.domain.models.SymptomLog
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.daysUntil
+import kotlinx.datetime.plus
+import kotlin.math.roundToInt
 
 /**
  * Analyzes user data to generate a list of actionable or interesting insights.
@@ -12,11 +16,6 @@ class InsightEngine {
 
     /**
      * The primary function that orchestrates the generation of all available insights.
-     *
-     * @param allCycles A complete list of the user's cycles.
-     * @param allSymptomLogs A complete list of all symptom log entries.
-     * @param symptomLibrary The user's symptom library for name lookups.
-     * @return A list of generated `Insight` objects, sorted by priority.
      */
     fun generateInsights(
         allCycles: List<Cycle>,
@@ -25,38 +24,61 @@ class InsightEngine {
     ): List<Insight> {
         val insights = mutableListOf<Insight>()
 
-        // --- Generator 1: Cycle Length Average ---
-        generateCycleLengthAverage(allCycles)?.let { insights.add(it) }
+        // Calculate the correct average cycle length once.
+        val averageCycleLength = calculateAverageCycleLength(allCycles)
 
-        // --- Generator 2: Symptom Recurrence ---
+        // --- Generator 1: Next Period Prediction ---
+        // This generator uses the calculated average.
+        if (averageCycleLength != null) {
+            generateNextPeriodPrediction(allCycles, averageCycleLength)?.let { insights.add(it) }
+        }
+
+        // --- Generator 2: Cycle Length Average ---
+        // This generator also uses the calculated average.
+        if (averageCycleLength != null) {
+            insights.add(CycleLengthAverage(averageCycleLength))
+        }
+
+        // --- Generator 3: Symptom Recurrence ---
         generateSymptomRecurrence(allSymptomLogs, symptomLibrary)?.let { insights.add(it) }
 
-        // Return all found insights, with the highest priority ones first.
         return insights.sortedByDescending { it.priority }
     }
 
-    /**
-     * Calculates the average length of a user's completed menstrual cycles.
-     * Requires at least two completed cycles to generate a meaningful average.
-     */
-    private fun generateCycleLengthAverage(allCycles: List<Cycle>): CycleLengthAverage? {
+    private fun calculateAverageCycleLength(allCycles: List<Cycle>): Double? {
         val completedCycles = allCycles.filter { it.endDate != null }
 
-        // We need at least two data points to calculate a meaningful average.
-        if (completedCycles.size < 2) {
+        // The repo sorts descending, so we reverse to get chronological order.
+        val chronologicalCycles = completedCycles.reversed()
+
+        // We need at least two cycles to calculate one duration between them.
+        if (chronologicalCycles.size < 2) {
             return null
         }
 
-        val average = completedCycles
-            .map { it.startDate.daysUntil(it.endDate!!) + 1 } // +1 to be inclusive
-            .average()
+        // Use zipWithNext to create pairs of consecutive cycles, e.g., (Cycle1, Cycle2), (Cycle2, Cycle3).
+        val cycleDurations = chronologicalCycles.zipWithNext { current, next ->
+            current.startDate.daysUntil(next.startDate).toDouble()
+        }
 
-        return CycleLengthAverage(average)
+        // It's possible to have cycles but no durations if there are fewer than 2.
+        if (cycleDurations.isEmpty()) return null
+
+        return cycleDurations.average()
     }
 
-    /**
-     * Identifies the symptom that has been logged most frequently by the user.
-     */
+    private fun generateNextPeriodPrediction(allCycles: List<Cycle>, averageLength: Double): NextPeriodPrediction? {
+        // The repository sorts cycles by start date descending, so the first is the latest.
+        val latestCycle = allCycles.firstOrNull() ?: return null
+
+        val averageLengthInDays = averageLength.roundToInt()
+
+        // The prediction is the start date of the last cycle plus the average length.
+        val predictedDate = latestCycle.startDate.plus(averageLengthInDays, DateTimeUnit.DAY)
+
+        return NextPeriodPrediction(predictedDate)
+    }
+
     private fun generateSymptomRecurrence(
         allSymptomLogs: List<SymptomLog>,
         symptomLibrary: List<Symptom>
@@ -64,17 +86,11 @@ class InsightEngine {
         if (allSymptomLogs.isEmpty()) {
             return null
         }
-
-        // Group logs by symptomId and find the group with the largest size.
         val mostFrequentEntry = allSymptomLogs
             .groupBy { it.symptomId }
             .maxByOrNull { it.value.size }
+            ?: return null
 
-        if (mostFrequentEntry == null) {
-            return null
-        }
-
-        // Look up the symptom's name from the library using its ID.
         val symptomInfo = symptomLibrary.find { it.id == mostFrequentEntry.key }
 
         return symptomInfo?.let {


### PR DESCRIPTION
- introduce NextPeriodPrediction insight with higher priority (110) than average (100) and symptom (90)

- compute average cycle length from consecutive start dates (chronological order, zipWithNext), ignore ongoing/incomplete data

- predict next period as latest start date plus rounded average length

- update InsightEngine to calculate shared average once, then emit prediction and average insights

- extend tests to cover prediction, average, and symptom-only scenarios with realistic multi-day periods

- ensure repository sort assumptions (descending by start date) are respected in calculations