### PR TITLE
feat(insights-ui): add localized date formatting for predictions and logs

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModel.kt
@@ -4,8 +4,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.veleda.cyclewise.domain.insights.Insight
 import com.veleda.cyclewise.domain.insights.InsightEngine
+import com.veleda.cyclewise.domain.insights.NextPeriodPrediction
+import com.veleda.cyclewise.domain.insights.SymptomPhasePattern
 import com.veleda.cyclewise.domain.repository.PeriodRepository
 import com.veleda.cyclewise.settings.AppSettings
+import com.veleda.cyclewise.ui.utils.toLocalizedDateString
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,18 +45,39 @@ class InsightsViewModel(
             val topSymptomsCount = appSettings.topSymptomsCount.first()
 
             // Run the analysis, passing the config value to the engine.
-            val generatedInsights = insightEngine.generateInsights(
+            val rawInsights = insightEngine.generateInsights(
                 allPeriods = allCycles,
                 allLogs = allLogs,
                 symptomLibrary = symptomLibrary,
                 topSymptomsCount = topSymptomsCount
             )
 
+            // Apply platform-specific formatting to the insights
+            val formattedInsights = rawInsights.map { insight ->
+                when (insight) {
+                    is NextPeriodPrediction -> {
+                        // Format the raw predicted date and create a new instance with the formatted string
+                        insight.copy(formattedDateString = insight.predictedDate.toLocalizedDateString())
+                    }
+                    is SymptomPhasePattern -> {
+                        val formattedDate = insight.predictedDate?.toLocalizedDateString()
+
+                        // Create a copy only if the formatted date was successfully generated
+                        if (formattedDate != null) {
+                            insight.copy(formattedPredictedDateString = formattedDate)
+                        } else {
+                            insight
+                        }
+                    }
+                    else -> insight
+                }
+            }
+
             // Update the state with the results
             _uiState.update {
                 it.copy(
                     isLoading = false,
-                    insights = generatedInsights
+                    insights = formattedInsights
                 )
             }
         }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
@@ -28,6 +28,7 @@ import com.veleda.cyclewise.domain.models.Medication
 import com.veleda.cyclewise.domain.models.MedicationLog
 import com.veleda.cyclewise.domain.models.Symptom
 import com.veleda.cyclewise.domain.models.SymptomLog
+import com.veleda.cyclewise.ui.utils.toLocalizedDateString
 import kotlinx.datetime.LocalDate
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.getKoin
@@ -89,7 +90,7 @@ fun DailyLogScreen(
                         .verticalScroll(rememberScrollState())
                 ) {
                     Text(
-                        text = "Log for ${log.entry.entryDate}",
+                        text = "Log for ${log.entry.entryDate.toLocalizedDateString()}",
                         style = MaterialTheme.typography.headlineSmall,
                         modifier = Modifier.padding(vertical = 16.dp)
                     )

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerScreen.kt
@@ -32,6 +32,8 @@ import com.kizitonwose.calendar.core.firstDayOfWeekFromLocale
 import com.veleda.cyclewise.domain.models.FullDailyLog
 import com.veleda.cyclewise.domain.models.Symptom
 import com.veleda.cyclewise.ui.nav.NavRoute
+import com.veleda.cyclewise.ui.utils.toLocalizedDateString
+import com.veleda.cyclewise.ui.utils.toLocalizedMonthYearString
 import kotlinx.coroutines.launch
 import kotlinx.datetime.toKotlinLocalDate
 import java.time.format.TextStyle
@@ -100,7 +102,7 @@ fun TrackerScreen(navController: NavController) {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = calendarState.firstVisibleMonth.yearMonth.toString(),
+                text = calendarState.firstVisibleMonth.yearMonth.toLocalizedMonthYearString(),
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
                 textAlign = TextAlign.Center
@@ -194,7 +196,7 @@ private fun LogSummarySheetContent(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "Log for ${log.entry.entryDate}",
+                text = "Log for ${log.entry.entryDate.toLocalizedDateString()}",
                 style = MaterialTheme.typography.titleLarge
             )
             Row { // Group Edit and Delete buttons

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/utils/DateFormatter.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/utils/DateFormatter.kt
@@ -1,0 +1,25 @@
+package com.veleda.cyclewise.ui.utils
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.number
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import java.time.YearMonth as JavaYearMonth
+
+/**
+ * Utility to format a kotlinx.datetime.LocalDate into a user-friendly, locale-aware String.
+ */
+fun LocalDate.toLocalizedDateString(): String {
+    val javaLocalDate = java.time.LocalDate.of(this.year, month.number, day)
+    // FormatStyle.LONG typically produces formats like "October 26, 2025" for US locale, respecting user's locale.
+    return javaLocalDate.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG))
+}
+
+/**
+ * Utility to format a java.time.YearMonth into a localized month and year string.
+ */
+fun JavaYearMonth.toLocalizedMonthYearString(): String {
+    // Use a custom pattern for Month and Year only, which still uses the default locale.
+    return this.format(DateTimeFormatter.ofPattern("MMMM yyyy", Locale.getDefault()))
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
@@ -35,22 +35,25 @@ data class CycleLengthAverage(
 
 /**
  * An insight that predicts the start date of the next menstrual period.
- * @param predictedDate The calculated date for the next period's start.
- * @param today The current date, used to create a dynamic description.
+ * @param predictedDate The calculated raw date for the next period's start.
+ * @param daysUntilPrediction The number of days from today until the predicted date.
+ * @param formattedDateString The localized date string for display (set by ViewModel).
  */
 data class NextPeriodPrediction @OptIn(ExperimentalTime::class) constructor(
     val predictedDate: LocalDate,
-    val today: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault())
+    val daysUntilPrediction: Int,
+    val formattedDateString: String = predictedDate.toString() // Default is raw string for non-Android targets
 ) : Insight {
     override val id: String = "NEXT_PERIOD_PREDICTION"
     override val title: String = "Next Period Forecast"
     override val description: String
         get() {
-            val days = today.daysUntil(predictedDate)
+            val days = daysUntilPrediction
+            val dateStr = formattedDateString
             return when {
                 days == 0 -> "Your next period is predicted to start today."
-                days > 0 -> "Your next period is predicted to start in $days days."
-                else -> "Your period was expected ${abs(days)} days ago."
+                days > 0 -> "Your next period is predicted to start in $days days (on $dateStr)."
+                else -> "Your period was expected ${abs(days)} days ago (on $dateStr)."
             }
         }
     override val priority: Int = 110
@@ -81,6 +84,7 @@ data class CycleLengthTrend(
  * @param symptomName The name of the recurring symptom.
  * @param phaseDescription A user-friendly description of the cycle phase (e.g., "during your period").
  * @param recurrenceRate A string representing the pattern's strength (e.g., "4 out of 5").
+ * @param formattedPredictedDateString The localized date string for display (set by ViewModel).
  */
 data class SymptomPhasePattern(
     val symptomName: String,
@@ -88,19 +92,22 @@ data class SymptomPhasePattern(
     val recurrenceRate: String,
     override val priority: Int,
     val predictedDate: LocalDate? = null,
-    val chanceDescription: String? = null
+    val chanceDescription: String? = null,
+    val formattedPredictedDateString: String? = null
 ) : Insight {
     override val id: String = "PATTERN_${symptomName}_$phaseDescription"
     override val title: String = "Symptom Pattern Detected"
     override val description: String
-        get() {
-            val baseDescription = "You've logged '$symptomName' $phaseDescription in $recurrenceRate of your recent cycles."
-            return if (predictedDate != null && chanceDescription != null) {
-                "$baseDescription Based on this, there is a $chanceDescription of it recurring on or around $predictedDate."
-            } else {
-                baseDescription
-            }
+    get() {
+        val dateStr = formattedPredictedDateString
+        val baseDescription = "You've logged '$symptomName' $phaseDescription in $recurrenceRate of your recent cycles."
+
+        return if (dateStr != null && chanceDescription != null) {
+            "$baseDescription Based on this, there is a $chanceDescription of it recurring on or around $dateStr."
+        } else {
+            baseDescription
         }
+    }
 }
 
 /**
@@ -118,15 +125,15 @@ data class MoodPhasePattern(
     override val id: String = "MOOD_PATTERN_${moodType}_$phaseDescription"
     override val title: String = "Mood Pattern Detected"
     override val description: String
-        get() {
-            val baseDescription = "You've logged a '$moodType' mood $phaseDescription in $recurrenceRate of your recent cycles."
-            val suffix = if (moodType == "low") {
-                "Being aware of this pattern can help you plan for self-care."
-            } else {
-                "Knowing this can help you schedule activities you enjoy."
-            }
-            return "$baseDescription $suffix"
+    get() {
+        val baseDescription = "You've logged a '$moodType' mood $phaseDescription in $recurrenceRate of your recent cycles."
+        val suffix = if (moodType == "low") {
+            "Being aware of this pattern can help you plan for self-care."
+        } else {
+            "Knowing this can help you schedule activities you enjoy."
         }
+        return "$baseDescription $suffix"
+    }
     override val priority: Int = 106
 }
 

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/NextPeriodPredictionGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/NextPeriodPredictionGenerator.kt
@@ -3,18 +3,33 @@ package com.veleda.cyclewise.domain.insights.generators
 import com.veleda.cyclewise.domain.insights.Insight
 import com.veleda.cyclewise.domain.insights.NextPeriodPrediction
 import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.daysUntil
 import kotlinx.datetime.plus
+import kotlinx.datetime.todayIn
 import kotlin.math.roundToInt
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 class NextPeriodPredictionGenerator : InsightGenerator {
+    @OptIn(ExperimentalTime::class)
     override fun generate(data: InsightData): List<Insight> {
         val latestCycle = data.allPeriods.firstOrNull()
         if (data.averageCycleLength == null || latestCycle == null) {
             return emptyList()
         }
 
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
         val averageLengthInDays = data.averageCycleLength.roundToInt()
         val predictedDate = latestCycle.startDate.plus(averageLengthInDays, DateTimeUnit.DAY)
-        return listOf(NextPeriodPrediction(predictedDate))
+
+        // Calculate the days until prediction
+        val daysUntil = today.daysUntil(predictedDate)
+
+        // Pass the raw date and the calculated daysUntil
+        return listOf(NextPeriodPrediction(
+            predictedDate = predictedDate,
+            daysUntilPrediction = daysUntil
+        ))
     }
 }


### PR DESCRIPTION
Introduces locale-aware date formatting utilities (`toLocalizedDateString` and `toLocalizedMonthYearString`) for Android UI components. Integrates formatted date strings into Insights, Tracker, and Daily Log screens, and updates `NextPeriodPrediction` and `SymptomPhasePattern` models to include formatted display fields.

This enhances readability of insights and log entries across locales.