### PR TITLE
docs(kdoc): add comprehensive KDoc documentation across codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ captures
 !*.xcodeproj/project.xcworkspace/
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
+nul

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/DailyEntryDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/DailyEntryDao.kt
@@ -5,6 +5,12 @@ import com.veleda.cyclewise.androidData.local.entities.DailyEntryEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 
+/**
+ * Room DAO for the `daily_entries` table.
+ *
+ * Each row represents a single day's health entry. Uses REPLACE conflict strategy
+ * on insert, so re-inserting for the same ID overwrites the existing row.
+ */
 @Dao
 interface DailyEntryDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/MedicationDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/MedicationDao.kt
@@ -8,6 +8,12 @@ import com.veleda.cyclewise.androidData.local.entities.MedicationEntity
 import com.veleda.cyclewise.androidData.local.entities.MedicationLogEntity
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Room DAO for the `medication_library` table.
+ *
+ * Manages the user's unique medication types. Names are unique (IGNORE on conflict).
+ * Results from [getAllMedications] are sorted by name ascending.
+ */
 @Dao
 interface MedicationDao {
     @Query("SELECT * FROM medication_library ORDER BY name ASC")

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/MedicationLogDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/MedicationLogDao.kt
@@ -7,6 +7,12 @@ import androidx.room.Query
 import com.veleda.cyclewise.androidData.local.entities.MedicationLogEntity
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Room DAO for the `medication_logs` table.
+ *
+ * Each row records that a medication was taken on a single day. Linked to `daily_entries`
+ * via `entry_id` (CASCADE delete) and to `medication_library` via `medication_id` (RESTRICT delete).
+ */
 @Dao
 interface MedicationLogDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/PeriodDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/PeriodDao.kt
@@ -6,10 +6,17 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 import kotlin.time.ExperimentalTime
 
+/**
+ * Room DAO for the `periods` table.
+ *
+ * Provides CRUD operations and reactive queries for [PeriodEntity].
+ * Periods are identified by an auto-generated internal [PeriodEntity.id] (PK)
+ * and an exposed [PeriodEntity.uuid] (UNIQUE TEXT).
+ */
 @OptIn(ExperimentalTime::class)
 @Dao
 interface PeriodDao {
-    /** All periods, newest first (by start_date). */
+    /** All periods, sorted by start_date descending (most recent first). */
     @Query("SELECT * FROM periods ORDER BY start_date DESC")
     fun getAllPeriods(): Flow<List<PeriodEntity>>
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/PeriodLogDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/PeriodLogDao.kt
@@ -8,6 +8,12 @@ import androidx.room.Update
 import com.veleda.cyclewise.androidData.local.entities.PeriodLogEntity
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Room DAO for the `period_logs` table.
+ *
+ * Each row records the flow intensity for a single day, linked to a [DailyEntryEntity]
+ * via `entry_id` FK (CASCADE delete). At most one period log exists per daily entry.
+ */
 @Dao
 interface PeriodLogDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/SymptomDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/SymptomDao.kt
@@ -7,6 +7,12 @@ import androidx.room.Query
 import com.veleda.cyclewise.androidData.local.entities.SymptomEntity
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Room DAO for the `symptom_library` table.
+ *
+ * Manages the user's unique symptom types. Names are unique (IGNORE on conflict).
+ * Results from [getAllSymptoms] are sorted by name ascending.
+ */
 @Dao
 interface SymptomDao {
     @Query("SELECT * FROM symptom_library ORDER BY name ASC")

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/SymptomLogDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/SymptomLogDao.kt
@@ -4,6 +4,12 @@ import androidx.room.*
 import com.veleda.cyclewise.androidData.local.entities.SymptomLogEntity
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Room DAO for the `symptom_logs` table.
+ *
+ * Each row records a symptom occurrence for a single day. Linked to `daily_entries`
+ * via `entry_id` (CASCADE delete) and to `symptom_library` via `symptom_id` (RESTRICT delete).
+ */
 @Dao
 interface SymptomLogDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/WaterIntakeDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/WaterIntakeDao.kt
@@ -6,6 +6,13 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.veleda.cyclewise.androidData.local.entities.WaterIntakeEntity
 
+/**
+ * Room DAO for the `water_intake` table.
+ *
+ * Uses the ISO-8601 date string as the primary key (one row per day, upsert semantics).
+ * Date parameters are passed as pre-formatted strings (not [LocalDate]) because
+ * the PK column is TEXT.
+ */
 @Dao
 interface WaterIntakeDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/PeriodDatabase.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/PeriodDatabase.kt
@@ -32,6 +32,17 @@ import com.veleda.cyclewise.androidData.local.entities.PeriodLogEntity
 import com.veleda.cyclewise.androidData.local.entities.WaterIntakeEntity
 import net.sqlcipher.database.SupportFactory
 
+/**
+ * SQLCipher-encrypted Room database for all user health data.
+ *
+ * Opened via [create] with a passphrase-derived key. The caller (session scope) is
+ * responsible for zeroizing the passphrase [ByteArray] after the database is opened.
+ *
+ * **Security:** All data at rest is AES-256-GCM encrypted via SQLCipher.
+ * The database file (`cyclewise.db`) is unreadable without the correct passphrase.
+ *
+ * **Schema version:** 9. All migrations are registered in [create] and tested individually.
+ */
 @Database(
     entities = [
         PeriodEntity::class,
@@ -58,6 +69,15 @@ abstract class PeriodDatabase : RoomDatabase() {
     abstract fun waterIntakeDao(): WaterIntakeDao
 
     companion object {
+        /**
+         * Creates (or opens) the encrypted database.
+         *
+         * @param context    application context for the Room builder.
+         * @param passphrase 32-byte AES key derived from the user's passphrase.
+         *                   **Caller must zeroize this array after this method returns.**
+         * @param dbName     database file name (default: "cyclewise.db").
+         * @return the opened [PeriodDatabase] instance.
+         */
         fun create(
             context: Context,
             passphrase: ByteArray,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_1_2.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_1_2.kt
@@ -3,6 +3,7 @@ package com.veleda.cyclewise.androidData.local.database.migrations
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/** v1 -> v2: Creates the `daily_entries` table with cycle_id FK, flow/spotting columns, and date index. */
 object Migration_1_2 : Migration(1, 2) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL(

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_2_3.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_2_3.kt
@@ -3,6 +3,7 @@ package com.veleda.cyclewise.androidData.local.database.migrations
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/** v2 -> v3: Creates the initial `symptoms` and `medication_logs` tables with entry_id FKs. */
 object Migration_2_3 : Migration(2, 3) {
     override fun migrate(db: SupportSQLiteDatabase) {
         // Create the 'symptoms' table

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_3_4.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_3_4.kt
@@ -3,6 +3,7 @@ package com.veleda.cyclewise.androidData.local.database.migrations
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/** v3 -> v4: Adds the `note` TEXT column to `daily_entries`. */
 object Migration_3_4 : Migration(3, 4) {
     override fun migrate(db: SupportSQLiteDatabase) {
         // Add the new 'note' column to the daily_entries table.

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_4_5.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_4_5.kt
@@ -4,6 +4,12 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.benasher44.uuid.uuid4
 
+/**
+ * v4 -> v5: Introduces the normalized medication library.
+ *
+ * Creates `medication_library` (unique name index) and new `medication_logs` (with FKs
+ * to `daily_entries` CASCADE and `medication_library` RESTRICT). Drops the old `medications` table.
+ */
 object Migration_4_5 : Migration(4, 5) {
     override fun migrate(db: SupportSQLiteDatabase) {
         // Step 1: Create the new medication_library table

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_5_6.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_5_6.kt
@@ -4,6 +4,14 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.benasher44.uuid.uuid4
 
+/**
+ * v5 -> v6: Introduces the normalized symptom library.
+ *
+ * Creates `symptom_library` (unique name index) and `symptom_logs` (with FKs to
+ * `daily_entries` CASCADE and `symptom_library` RESTRICT). Migrates existing data from
+ * the old `symptoms` table: extracts unique symptom types into the library, maps old log
+ * entries to the new FK-based schema, then drops the old table.
+ */
 object Migration_5_6 : Migration(5, 6) {
     override fun migrate(db: SupportSQLiteDatabase) {
         // Step 1: Create the new symptom_library table

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_6_7.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_6_7.kt
@@ -3,6 +3,12 @@ package com.veleda.cyclewise.androidData.local.database.migrations
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * v6 -> v7: Removes the `cycle_id` FK column from `daily_entries`.
+ *
+ * Uses the SQLite table-rebuild pattern (create new -> copy data -> drop old -> rename)
+ * because SQLite does not support DROP COLUMN or DROP FOREIGN KEY directly.
+ */
 object Migration_6_7 : Migration(6, 7) {
     override fun migrate(db: SupportSQLiteDatabase) {
         // SQLite doesn't directly support dropping columns or foreign keys easily.

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_7_8.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_7_8.kt
@@ -6,6 +6,15 @@ import com.benasher44.uuid.uuid4
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+/**
+ * v7 -> v8: Extracts flow data into a separate `period_logs` table.
+ *
+ * Steps:
+ * 1. Creates `period_logs` with `entry_id` FK (CASCADE) to `daily_entries`.
+ * 2. Creates a new `daily_entries` table without `flow_intensity` and `spotting` columns.
+ * 3. Migrates non-null `flow_intensity` rows into `period_logs`.
+ * 4. Copies remaining columns to the new table, drops the old, and renames.
+ */
 @OptIn(ExperimentalTime::class)
 object Migration_7_8 : Migration(7, 8) {
     override fun migrate(db: SupportSQLiteDatabase) {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_8_9.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/migrations/Migration_8_9.kt
@@ -3,6 +3,7 @@ package com.veleda.cyclewise.androidData.local.database.migrations
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/** v8 -> v9: Creates the `water_intake` table with date as TEXT PK and cups/timestamp columns. */
 object Migration_8_9 : Migration(8, 9) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL("""

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/draft/LockedWaterDraft.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/draft/LockedWaterDraft.kt
@@ -32,6 +32,18 @@ data class WaterDraftEntry(
     val cups: Int
 )
 
+/**
+ * DataStore-backed draft storage for water intake tracked before authentication.
+ *
+ * Allows the user to log water cups on the lock screen without unlocking the encrypted
+ * database. Drafts are stored as a JSON-serialized [WaterDraftPayload] in plaintext
+ * DataStore preferences. On successful unlock, [WaterDraftSyncer] transfers qualifying
+ * drafts into the encrypted database.
+ *
+ * **Auto-prune:** [setCups] removes entries older than 29 days.
+ * **Day rollover:** [ensureRolledOver] detects day changes and resets today's entry.
+ * **Max cups:** Clamped to [MAX_DRAFT_CUPS] (99).
+ */
 class LockedWaterDraft(private val context: Context) {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -88,7 +100,6 @@ class LockedWaterDraft(private val context: Context) {
             val raw = prefs[PAYLOAD_KEY]
 
             if (raw == null) {
-                // First install: create and persist default payload
                 val default = WaterDraftPayload(
                     version = 1,
                     lastActiveDate = today.toString(),
@@ -102,7 +113,6 @@ class LockedWaterDraft(private val context: Context) {
             val lastActive = runCatching { LocalDate.parse(payload.lastActiveDate) }.getOrNull()
 
             if (lastActive == null) {
-                // Corrupted/blank lastActiveDate: reset gracefully
                 val reset = WaterDraftPayload(
                     version = 1,
                     lastActiveDate = today.toString(),
@@ -113,17 +123,14 @@ class LockedWaterDraft(private val context: Context) {
             }
 
             if (lastActive == today) {
-                // Already rolled over today: no-op
                 return@edit
             }
 
-            // Day changed: prune old entries and update lastActiveDate
             val cutoff = today.minus(29, DateTimeUnit.DAY)
             val prunedEntries = payload.entries.mapNotNull { entry ->
                 val d = runCatching { LocalDate.parse(entry.date) }.getOrNull() ?: return@mapNotNull null
                 if (d < cutoff) null else entry
             }
-            // Ensure today's entry is absent (missing = 0, no explicit zeros)
             val withoutToday = prunedEntries.filter { it.date != today.toString() }
 
             val updated = payload.copy(

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/Converters.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/Converters.kt
@@ -9,7 +9,12 @@ import kotlinx.datetime.LocalDate
 import kotlin.time.ExperimentalTime
 
 /**
- * Room type converters for kotlinx-datetime types.
+ * Room type converters for non-primitive column types.
+ *
+ * Serialization formats:
+ * - [LocalDate] <-> ISO-8601 string (e.g., "2025-01-15")
+ * - [Instant] <-> epoch milliseconds ([Long])
+ * - [FlowIntensity], [LibidoLevel], [SymptomCategory] <-> enum name string (e.g., "HEAVY")
  */
 object Converters {
     @TypeConverter
@@ -27,18 +32,10 @@ object Converters {
     fun toInstant(value: Long): Instant = Instant.fromEpochMilliseconds(value)
 
     @TypeConverter
-    fun fromFlowIntensity(value: FlowIntensity?): String? {
-        // Converts the enum to its String name for storing in the database.
-        // E.g., FlowIntensity.HEAVY -> "HEAVY"
-        return value?.name
-    }
+    fun fromFlowIntensity(value: FlowIntensity?): String? = value?.name
 
     @TypeConverter
-    fun toFlowIntensity(value: String?): FlowIntensity? {
-        // Converts a String from the database back into the corresponding enum.
-        // E.g., "HEAVY" -> FlowIntensity.HEAVY
-        return value?.let { FlowIntensity.valueOf(it) }
-    }
+    fun toFlowIntensity(value: String?): FlowIntensity? = value?.let { FlowIntensity.valueOf(it) }
 
     @TypeConverter
     fun fromLibidoLevel(value: LibidoLevel?): String? {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/DailyEntryEntity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/DailyEntryEntity.kt
@@ -8,11 +8,17 @@ import kotlinx.datetime.LocalDate
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * Room entity for the `daily_entries` table.
+ *
+ * Maps to the domain [DailyEntry] model. The [libidoLevel] is stored as the enum name
+ * string (nullable). The [customTags] field is a JSON-serialized string array.
+ * Timestamps ([createdAt], [updatedAt]) are stored as epoch milliseconds.
+ */
 @OptIn(ExperimentalTime::class)
 @Entity(
     tableName = "daily_entries"
 )
-
 data class DailyEntryEntity(
     @PrimaryKey val id: String,
     @ColumnInfo(name = "entry_date", index = true) val entryDate: LocalDate,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/Mappers.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/Mappers.kt
@@ -1,3 +1,13 @@
+/**
+ * Bidirectional mappers between Room entities and shared domain models.
+ *
+ * Each entity type has a `toDomain()` extension (entity -> domain) and a `toEntity()`
+ * extension (domain -> entity). For [PeriodEntity], the internal auto-generated [PeriodEntity.id]
+ * is set to 0 on `toEntity()` so Room auto-generates it on insert.
+ *
+ * [DailyEntryEntity.customTags] is JSON-serialized/deserialized via kotlinx.serialization.
+ * [WaterIntakeEntity.date] is converted between ISO-8601 string and [LocalDate].
+ */
 package com.veleda.cyclewise.androidData.local.entities
 
 import com.veleda.cyclewise.domain.models.Period
@@ -27,7 +37,7 @@ fun PeriodEntity.toDomain(): Period =
 @OptIn(ExperimentalTime::class)
 fun Period.toEntity(): PeriodEntity =
     PeriodEntity(
-        id        = 0,           //  Room will auto-generate
+        id        = 0,
         uuid      = id,
         startDate = startDate,
         endDate   = endDate,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/MedicationEntity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/MedicationEntity.kt
@@ -7,13 +7,18 @@ import androidx.room.PrimaryKey
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * Room entity for the `medication_library` table.
+ *
+ * Each row is a unique medication type. The [name] column has a UNIQUE index.
+ */
 @OptIn(ExperimentalTime::class)
 @Entity(
     tableName = "medication_library",
-    indices = [Index(value = ["name"], unique = true)] // Ensure medication names are unique
+    indices = [Index(value = ["name"], unique = true)]
 )
 data class MedicationEntity(
-    @PrimaryKey val id: String, // UUID
+    @PrimaryKey val id: String,
     @ColumnInfo(name = "name") val name: String,
     @ColumnInfo(name = "created_at") val createdAt: Instant
 )

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/MedicationLogEntity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/MedicationLogEntity.kt
@@ -6,6 +6,12 @@ import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import kotlin.time.Instant
 
+/**
+ * Room entity for the `medication_logs` table.
+ *
+ * Records that a medication was taken on a single day. FK to `daily_entries` (CASCADE)
+ * and to `medication_library` (RESTRICT — cannot delete a medication type while logs reference it).
+ */
 @Entity(
     tableName = "medication_logs",
     foreignKeys = [
@@ -19,12 +25,12 @@ import kotlin.time.Instant
             entity = MedicationEntity::class,
             parentColumns = ["id"],
             childColumns = ["medication_id"],
-            onDelete = ForeignKey.RESTRICT // Prevent deleting a medication if it's in use
+            onDelete = ForeignKey.RESTRICT
         )
     ]
 )
 data class MedicationLogEntity(
-    @PrimaryKey val id: String, // UUID
+    @PrimaryKey val id: String,
     @ColumnInfo(name = "entry_id", index = true) val entryId: String,
     @ColumnInfo(name = "medication_id", index = true) val medicationId: String,
     @ColumnInfo(name = "created_at") val createdAt: Instant

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/PeriodLogEntity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/PeriodLogEntity.kt
@@ -8,6 +8,13 @@ import com.veleda.cyclewise.domain.models.FlowIntensity
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * Room entity for the `period_logs` table.
+ *
+ * Records menstrual flow intensity for a single day. Linked to [DailyEntryEntity]
+ * via `entry_id` FK with CASCADE delete. The [flowIntensity] enum is stored as its
+ * name string via [Converters].
+ */
 @OptIn(ExperimentalTime::class)
 @Entity(
     tableName = "period_logs",
@@ -16,12 +23,12 @@ import kotlin.time.Instant
             entity = DailyEntryEntity::class,
             parentColumns = ["id"],
             childColumns = ["entry_id"],
-            onDelete = ForeignKey.CASCADE // PeriodLog is deleted if DailyEntry is deleted
+            onDelete = ForeignKey.CASCADE
         )
     ]
 )
 data class PeriodLogEntity(
-    @PrimaryKey val id: String, // UUID
+    @PrimaryKey val id: String,
     @ColumnInfo(name = "entry_id", index = true) val entryId: String,
     @ColumnInfo(name = "flow_intensity") val flowIntensity: FlowIntensity,
     @ColumnInfo(name = "created_at") val createdAt: Instant,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/SymptomEntity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/SymptomEntity.kt
@@ -8,12 +8,18 @@ import androidx.room.*
 import com.veleda.cyclewise.domain.models.SymptomCategory
 import kotlin.time.Instant
 
+/**
+ * Room entity for the `symptom_library` table.
+ *
+ * Each row is a unique symptom type. The [name] column has a UNIQUE index.
+ * The [category] enum is stored as its name string via [Converters].
+ */
 @Entity(
     tableName = "symptom_library",
     indices = [Index(value = ["name"], unique = true)]
 )
 data class SymptomEntity(
-    @PrimaryKey val id: String, // UUID
+    @PrimaryKey val id: String,
     @ColumnInfo(name = "name") val name: String,
     @ColumnInfo(name = "category") val category: SymptomCategory,
     @ColumnInfo(name = "created_at") val createdAt: Instant

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/SymptomLogEntity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/SymptomLogEntity.kt
@@ -4,6 +4,13 @@ import androidx.room.*
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * Room entity for the `symptom_logs` table.
+ *
+ * Records a symptom occurrence for a single day. FK to `daily_entries` (CASCADE)
+ * and to `symptom_library` (RESTRICT — cannot delete a symptom type while logs reference it).
+ * Severity is an integer in the range 1-5.
+ */
 @OptIn(ExperimentalTime::class)
 @Entity(
     tableName = "symptom_logs",
@@ -23,9 +30,9 @@ import kotlin.time.Instant
     ]
 )
 data class SymptomLogEntity(
-    @PrimaryKey val id: String, // UUID of the log
+    @PrimaryKey val id: String,
     @ColumnInfo(name = "entry_id", index = true) val entryId: String,
     @ColumnInfo(name = "symptom_id", index = true) val symptomId: String,
-    @ColumnInfo(name = "severity") val severity: Int, // 1-5
+    @ColumnInfo(name = "severity") val severity: Int,
     @ColumnInfo(name = "created_at") val createdAt: Instant
 )

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/WaterIntakeEntity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/entities/WaterIntakeEntity.kt
@@ -6,10 +6,16 @@ import androidx.room.PrimaryKey
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * Room entity for the `water_intake` table.
+ *
+ * Uses the ISO-8601 date string as the primary key (one row per day, upsert semantics).
+ * Timestamps are stored as epoch milliseconds.
+ */
 @OptIn(ExperimentalTime::class)
 @Entity(tableName = "water_intake")
 data class WaterIntakeEntity(
-    @PrimaryKey val date: String, // ISO-8601 LocalDate
+    @PrimaryKey val date: String,
     @ColumnInfo(name = "cups") val cups: Int,
     @ColumnInfo(name = "created_at") val createdAt: Instant,
     @ColumnInfo(name = "updated_at") val updatedAt: Instant

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomPeriodRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomPeriodRepository.kt
@@ -48,7 +48,16 @@ import com.veleda.cyclewise.androidData.local.entities.PeriodEntity
 
 /**
  * Room-backed implementation of [PeriodRepository].
- * All data access is routed through SQLCipher-encrypted DAOs within a session scope.
+ *
+ * All data access is routed through SQLCipher-encrypted DAOs. This class lives inside
+ * the session scope — it is created after passphrase unlock and destroyed on logout/autolock.
+ *
+ * Key behaviors:
+ * - [saveFullLog] uses delete-then-insert within a Room transaction for child records.
+ * - [logPeriodDay] implements a 4-scenario state machine (see [PeriodRepository] KDoc).
+ * - [unLogPeriodDay] implements a 4-scenario deletion/split state machine.
+ * - [observeDayDetails] combines period ranges and log data into the calendar's source of truth.
+ * - [seedDatabaseForDebug] is destructive and generates 6 months of test data.
  */
 class RoomPeriodRepository(
     private val db: PeriodDatabase,
@@ -379,8 +388,8 @@ class RoomPeriodRepository(
     }
 
     /**
-     * [DEBUG ONLY] Clears all user data and seeds the database with a fresh,
-     * realistic dataset of 6 completed periods ending yesterday.
+     * **[DEBUG ONLY]** Clears all user data and seeds the database with 6 completed
+     * periods spanning several months, each with daily entries, symptoms, and medications.
      */
     override suspend fun seedDatabaseForDebug() {
         prepopulateSymptomLibrary()

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
@@ -33,8 +33,26 @@ import com.veleda.cyclewise.ui.insights.InsightsViewModel
 import kotlinx.datetime.LocalDate
 import org.koin.core.qualifier.Qualifier
 
+/**
+ * Koin qualifier for the session-scoped DI lifetime.
+ *
+ * The session scope is created after a successful passphrase unlock and destroyed on
+ * logout or autolock. It contains the encrypted database, all DAOs, the repository,
+ * use cases, library providers, and session-bound ViewModels.
+ */
 val SESSION_SCOPE: Qualifier = named("UnlockedSessionScope")
 
+/**
+ * Root Koin module defining two DI lifetimes:
+ *
+ * **Singleton scope** (lives for the app process):
+ * [SaltStorage], [AppSettings], [SessionBus], [PassphraseService], [LockedWaterDraft],
+ * [InsightEngine], [WaterTrackerViewModel], [PassphraseViewModel].
+ *
+ * **Session scope** ([SESSION_SCOPE], created on unlock, destroyed on logout/autolock):
+ * [PeriodDatabase], all DAOs, [PeriodRepository], use cases, library providers,
+ * [TrackerViewModel], [DailyLogViewModel], [InsightsViewModel].
+ */
 val appModule = module {
     single { SaltStorage(androidContext()) }
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/PassphraseServiceAndroid.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/PassphraseServiceAndroid.kt
@@ -5,24 +5,33 @@ import org.bouncycastle.crypto.params.Argon2Parameters
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator
 
 
+/**
+ * Android implementation of [PassphraseService] using Argon2id KDF (via BouncyCastle).
+ *
+ * **KDF parameters:**
+ * - Algorithm: Argon2id (resistant to both side-channel and GPU attacks)
+ * - Parallelism: 1
+ * - Memory: 64 MB (64 * 1024 KB)
+ * - Iterations: 3
+ * - Output key length: 32 bytes (256-bit AES)
+ *
+ * The salt is a stable 16-byte value stored in plaintext [SaltStorage] (not secret).
+ */
 class PassphraseServiceAndroid(
-    private val saltStorage: SaltStorage) : PassphraseService {
-    private val keyLength = 32 // 256-bit
+    private val saltStorage: SaltStorage
+) : PassphraseService {
+    private val keyLength = 32
 
     override fun deriveKey(passphrase: String): ByteArray {
-
-        // 1) get-or-create a stable salt
         val salt = saltStorage.getOrCreateSalt()
 
-        // 2) build Argon2 parameters
         val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
             .withSalt(salt)
             .withParallelism(1)
-            .withMemoryAsKB(64 * 1024)   // 64 MB
+            .withMemoryAsKB(64 * 1024)
             .withIterations(3)
             .build()
 
-        // 3) derive
         val generator = Argon2BytesGenerator().apply { init(params) }
         val key = ByteArray(keyLength)
         generator.generateBytes(passphrase.toCharArray(), key, 0, keyLength)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/SaltStorage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/SaltStorage.kt
@@ -21,12 +21,17 @@ class SaltStorage(context: Context) {
     private val prefs: SharedPreferences =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
+    /**
+     * Returns the persisted 16-byte salt, generating and saving one on first call.
+     *
+     * Uses [SecureRandom] for generation and Base64 for SharedPreferences storage.
+     * The salt is not secret — it only ensures that identical passphrases on different
+     * devices produce different derived keys.
+     */
     fun getOrCreateSalt(): ByteArray {
-        // 1) Return existing if present
         prefs.getString(SALT_KEY, null)?.let { base64 ->
             return Base64.decode(base64, Base64.DEFAULT)
         }
-        // 2) Otherwise generate, save, and return
         val salt = ByteArray(SALT_SIZE).also { SecureRandom().nextBytes(it) }
         val encoded = Base64.encodeToString(salt, Base64.NO_WRAP)
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/session/SessionBus.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/session/SessionBus.kt
@@ -5,8 +5,13 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 
 /**
- * Tiny event bus for session-level signals (e.g., logout).
- * Keeps UI decoupled from lifecycle observers and DI internals.
+ * Singleton event bus for session-level signals (e.g., logout).
+ *
+ * Keeps UI decoupled from lifecycle observers and DI internals. Collectors on the
+ * [logout] flow are notified when the session scope should be torn down.
+ *
+ * @property logout [SharedFlow] with replay = 0 and capacity 1 (drops oldest on overflow).
+ *                  Emits [Unit] when the user logs out or autolock triggers.
  */
 class SessionBus {
     private val _logout = MutableSharedFlow<Unit>(
@@ -16,6 +21,7 @@ class SessionBus {
     )
     val logout: SharedFlow<Unit> = _logout
 
+    /** Fires a logout signal. Non-suspending (uses [MutableSharedFlow.tryEmit]). */
     fun emitLogout() {
         _logout.tryEmit(Unit)
     }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
@@ -12,23 +12,30 @@ private val Context.dataStore by preferencesDataStore("app_settings")
 private val AUTOLOCK_MIN = intPreferencesKey("autolock_min")
 private val TOP_SYMPTOMS_COUNT = intPreferencesKey("top_symptoms_count")
 
+/**
+ * DataStore-backed wrapper for user-configurable app preferences.
+ *
+ * All properties are exposed as cold [Flow]s that emit the current value on subscription.
+ * Singleton-scoped (lives for the app process).
+ *
+ * @property autolockMinutes   Inactivity timeout before auto-lock, in minutes (default: 10).
+ * @property topSymptomsCount  Number of top symptoms shown in the recurrence insight (default: 3).
+ * @property isPrepopulated    Whether the default symptom library has been seeded on first unlock.
+ */
 class AppSettings(private val context: Context) {
-    // Auto-Lock
     val autolockMinutes = context.dataStore.data.map { prefs -> prefs[AUTOLOCK_MIN] ?: 10 }
     suspend fun setAutolockMinutes(min: Int) {
         context.dataStore.edit { it[AUTOLOCK_MIN] = min }
     }
 
-    // Expose the setting as a Flow, defaulting to 3
     val topSymptomsCount: Flow<Int> = context.dataStore.data.map { prefs ->
         prefs[TOP_SYMPTOMS_COUNT] ?: 3
     }
-    // Provide a way to change the setting
+
     suspend fun setTopSymptomsCount(count: Int) {
         context.dataStore.edit { it[TOP_SYMPTOMS_COUNT] = count }
     }
 
-    // Pre-populated symptoms
     private val IS_PREPOPULATED = booleanPreferencesKey("is_prepopulated")
 
     val isPrepopulated: Flow<Boolean> = context.dataStore.data

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
@@ -19,6 +19,21 @@ data class PassphraseUiState(
     val isUnlocking: Boolean = false
 )
 
+/**
+ * Handles passphrase unlock and session scope lifecycle.
+ *
+ * On [PassphraseEvent.UnlockClicked]:
+ * 1. Derives the encryption key via [PassphraseService] (on [Dispatchers.IO]).
+ * 2. Creates or reuses the Koin session scope and opens the encrypted database.
+ * 3. Prepopulates the symptom library on first unlock.
+ * 4. Syncs water drafts from [LockedWaterDraft] into the database.
+ * 5. Emits [PassphraseEffect.NavigateToTracker] on success.
+ *
+ * **Re-entrancy guard:** Ignores unlock requests while [PassphraseUiState.isUnlocking] is true.
+ * **Error handling:** On failure, the session scope is closed and [PassphraseEffect.ShowError] is emitted.
+ *
+ * Singleton-scoped (survives screen rotation).
+ */
 class PassphraseViewModel(
     private val appSettings: AppSettings,
     private val lockedWaterDraft: LockedWaterDraft

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/WaterDraftSyncer.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/WaterDraftSyncer.kt
@@ -9,6 +9,15 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import kotlin.time.Clock
 
+/**
+ * Syncs water intake drafts from [LockedWaterDraft] into the encrypted database after unlock.
+ *
+ * **Sync rules:**
+ * - Today's draft is skipped (the user may still be editing it).
+ * - A draft is written to the DB only if its cup count exceeds the existing DB value for that date.
+ * - Successfully synced dates are cleared from the draft store.
+ * - Individual date failures are logged but do not abort the remaining sync.
+ */
 class WaterDraftSyncer(
     private val lockedWaterDraft: LockedWaterDraft,
     private val repository: PeriodRepository

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/WaterTrackerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/WaterTrackerViewModel.kt
@@ -18,6 +18,16 @@ data class WaterTrackerUiState(
     val yesterdayMessage: String? = null
 )
 
+/**
+ * Pre-authentication water intake tracker for the lock screen.
+ *
+ * Reads and writes to [LockedWaterDraft] (plaintext DataStore) since the encrypted
+ * database is not yet available. On init, ensures the day has rolled over (resets
+ * today's count and prunes old entries), then continuously collects draft changes.
+ *
+ * Exposes today's cup count and an optional "yesterday" message prompting the user
+ * to log in so drafts can be synced to the encrypted database.
+ */
 class WaterTrackerViewModel(
     private val lockedWaterDraft: LockedWaterDraft
 ) : ViewModel() {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/insights/InsightsViewModel.kt
@@ -21,6 +21,15 @@ data class InsightsUiState(
     val insights: List<Insight> = emptyList()
 )
 
+/**
+ * Generates and formats cycle insights on init.
+ *
+ * Fetches all periods, logs, and the symptom library in one shot, runs the [InsightEngine],
+ * and applies platform-specific localized date formatting to [NextPeriodPrediction] and
+ * [SymptomPhasePattern] insights before emitting the final list to [uiState].
+ *
+ * Session-scoped (destroyed on logout/autolock).
+ */
 class InsightsViewModel(
     private val periodRepository: PeriodRepository,
     private val insightEngine: InsightEngine,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogEvent.kt
@@ -5,6 +5,12 @@ import com.veleda.cyclewise.domain.models.FullDailyLog
 import com.veleda.cyclewise.domain.models.Medication
 import com.veleda.cyclewise.domain.models.Symptom
 
+/**
+ * All events that can be dispatched to [DailyLogViewModel.onEvent].
+ *
+ * Includes data-loading events (dispatched internally by the ViewModel's init block),
+ * user-interaction events (from the UI), and the save/water actions.
+ */
 sealed interface DailyLogEvent {
     data class LogLoaded(val log: FullDailyLog?, val initialSymptoms: List<Symptom>, val initialMedications: List<Medication>) : DailyLogEvent
     data class LibraryUpdated(val symptoms: List<Symptom>, val medications: List<Medication>) : DailyLogEvent

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModel.kt
@@ -26,7 +26,17 @@ import kotlin.time.Clock
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-// Represents the state of the UI, holding the FullDailyLog
+/**
+ * UI state for the daily log editing screen.
+ *
+ * @property isLoading          True during the initial data fetch.
+ * @property log                The [FullDailyLog] being edited, or null if load failed.
+ * @property error              Error message to display (e.g., no parent period found).
+ * @property symptomLibrary     Current symptom library for the toggle list.
+ * @property medicationLibrary  Current medication library for the toggle list.
+ * @property isPeriodDay        Whether the date being edited falls within a period.
+ * @property waterCups          Water intake count for this date.
+ */
 data class DailyLogUiState(
     val isLoading: Boolean = true,
     val log: FullDailyLog? = null,
@@ -37,6 +47,22 @@ data class DailyLogUiState(
     val waterCups: Int = 0
 )
 
+/**
+ * Daily log entry editor ViewModel.
+ *
+ * Uses a pure-reducer MVI pattern: [onEvent] dispatches to [reduce], which returns
+ * updated state without side effects. Async operations (save, library creation) are
+ * launched via `viewModelScope` inside the relevant event branch.
+ *
+ * **Two-phase init:**
+ * 1. Fetches the initial log, symptom library, medication library, and water intake.
+ * 2. Subscribes to library changes for live updates during editing.
+ *
+ * **Empty log detection:** [isLogEmpty] determines if a log contains no user-entered
+ * data; empty logs are not persisted on save.
+ *
+ * Session-scoped (destroyed on logout/autolock).
+ */
 class DailyLogViewModel(
     private val entryDate: LocalDate,
     private val periodRepository: PeriodRepository,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
@@ -32,6 +32,20 @@ data class TrackerUiState(
     val ongoingPeriod: Period? = periods.find { it.endDate == null }
 }
 
+/**
+ * Calendar/tracker screen ViewModel managing period and log state.
+ *
+ * Uses a MVI-inspired pattern: [onEvent] dispatches to [reduce] (a pure function that
+ * returns updated state). Side effects (navigation, repository writes) are launched
+ * inside `reduce` via `viewModelScope`.
+ *
+ * **Init:** Collects 4 reactive flows — day details, periods, symptom library, and
+ * medication library — each updating the corresponding [TrackerUiState] field.
+ *
+ * **Effects:** One-shot navigation events are emitted via [_effect] ([SharedFlow] with replay = 0).
+ *
+ * Session-scoped (destroyed on logout/autolock).
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TrackerViewModel(
     private val periodRepository: PeriodRepository,

--- a/docs/architecture/DOCUMENTATION_GUIDELINES.md
+++ b/docs/architecture/DOCUMENTATION_GUIDELINES.md
@@ -1,0 +1,148 @@
+# Documentation Guidelines
+
+Standards for KDoc documentation across the RhythmWise codebase. All subsequent documentation PRs reference this guide.
+
+---
+
+## What Must Be Documented
+
+### Always Document
+- **Public classes and interfaces** — Class-level KDoc explaining purpose, lifetime, and key invariants
+- **Public functions with non-trivial behavior** — `@param`, `@return`, side effects, threading expectations
+- **Domain invariants** — Value ranges (e.g., `moodScore` 1-5), state transitions, sorting guarantees
+- **Repository contracts** — Cold Flow vs suspend, nullability semantics, transactional expectations
+- **Complex private logic** — Algorithms with magic numbers, multi-step state machines, normalization formulas
+- **Security-critical code** — KDF parameters, encryption setup, key lifecycle, passphrase handling
+
+### Never Document
+- Trivial getters/setters where the name is self-explanatory
+- Self-evident one-liner functions (e.g., `fun toEntity() = Entity(id, name)`)
+- Test files (use descriptive test names instead)
+- Compose `@Composable` screen functions (their behavior is defined by ViewModel contracts)
+- Code that restates what the code literally does (e.g., `/** Returns the id. */ fun getId() = id`)
+
+---
+
+## KDoc Formatting Rules
+
+### Class-Level Documentation
+Every public class/interface gets a class-level KDoc block explaining:
+1. What it represents or does
+2. Its lifetime/scope (singleton, session-scoped, per-screen)
+3. Key invariants or constraints
+
+```kotlin
+/**
+ * Room entity representing a single menstrual period.
+ *
+ * Mapped to the `periods` table. Uses an auto-generated [id] for internal Room joins
+ * and an exposed [uuid] (TEXT UNIQUE) for domain-layer identification.
+ *
+ * **Invariant:** [startDate] <= [endDate] when [endDate] is non-null.
+ * A null [endDate] indicates an ongoing period.
+ *
+ * @property id      Auto-generated internal PK for Room (fast joins/indexing).
+ * @property uuid    External UUID exposed to the domain and sync layers.
+ * @property startDate The first day of this period.
+ * @property endDate   The last day of this period, or null if ongoing.
+ * @property createdAt Timestamp when this record was first persisted.
+ * @property updatedAt Timestamp of the most recent modification.
+ */
+```
+
+### Domain Models
+Use `@property` tags for every property with non-obvious semantics:
+
+```kotlin
+/**
+ * A day's complete health entry, linked to a parent period by date proximity.
+ *
+ * @property id        UUID primary key.
+ * @property entryDate Calendar date this entry represents.
+ * @property dayInCycle 1-based offset from the parent period's start date.
+ * @property moodScore  User-rated mood on a 1 (lowest) to 5 (highest) scale, or null if unrecorded.
+ * @property energyLevel User-rated energy on a 1-5 scale, or null if unrecorded.
+ * @property customTags  Freeform user tags stored as a JSON-serialized list of strings.
+ */
+```
+
+### Repository and Interface Methods
+Document `@param`, `@return`, threading model, and side effects:
+
+```kotlin
+/**
+ * Marks [date] as a period day, merging or extending adjacent periods as needed.
+ *
+ * Runs inside a Room transaction. Handles four scenarios:
+ * 1. **Already inside a period** — ensures a PeriodLog exists for the date.
+ * 2. **Bridges two periods** — merges the adjacent periods into one.
+ * 3. **Extends a period** — adjusts the neighboring period's start or end date.
+ * 4. **Island day** — creates a new single-day completed period.
+ *
+ * @param date the calendar date to mark as a period day.
+ */
+suspend fun logPeriodDay(date: LocalDate)
+```
+
+### Use Cases
+Document preconditions, postconditions, and return semantics:
+
+```kotlin
+/**
+ * Starts a new menstrual period beginning on [startDate].
+ *
+ * **Precondition:** No ongoing period exists (endDate == null).
+ * **Postcondition:** A new [Period] with a null endDate is persisted.
+ *
+ * @return the newly created [Period], or null if an ongoing period already exists.
+ */
+```
+
+### Complex Private Helpers
+Document the algorithm, magic numbers, and edge cases:
+
+```kotlin
+/**
+ * Groups a sorted list of day-offsets into runs of consecutive integers.
+ *
+ * For example, `[1, 2, 3, 7, 8]` becomes `[[1, 2, 3], [7, 8]]`.
+ * Used to identify contiguous symptom clusters within a cycle phase.
+ *
+ * @param days sorted, distinct normalized day offsets.
+ * @return a list of consecutive-day groups, each sorted ascending.
+ */
+private fun groupConsecutiveDays(days: List<Int>): List<List<Int>>
+```
+
+---
+
+## Threading and Coroutine Rules
+
+- **`suspend` functions** — May be called from any dispatcher unless documented otherwise. Repository `suspend` functions are safe to call from `Dispatchers.Main` (Room handles IO internally).
+- **`Flow` return types** — Always cold Flows backed by Room's reactive queries. Collectors receive the latest snapshot on subscription and subsequent updates.
+- **`SharedFlow` / `MutableSharedFlow`** — Document `replay` and buffer policy (e.g., "replay = 0, drops oldest on overflow").
+- **`viewModelScope.launch`** — Runs on `Dispatchers.Main` by default. Document when `withContext(Dispatchers.IO)` is used for blocking work.
+
+---
+
+## Invariant Documentation
+
+Always document:
+- **Value ranges** — `moodScore: 1-5`, `severity: 1-5`, `cups: 0-99`
+- **Nullability semantics** — `null endDate = ongoing period`, `null moodScore = unrecorded`
+- **Sorting guarantees** — `getAllPeriods()` returns periods sorted by start date descending
+- **State transitions** — the 4-scenario FSMs for `logPeriodDay` / `unLogPeriodDay`
+- **One-row constraints** — `WaterIntake` uses date as natural key (one row per day)
+- **FK relationships** — CASCADE (deleting parent deletes children) vs RESTRICT (cannot delete parent while children exist)
+
+---
+
+## Style Rules
+
+- Write in third person ("Returns the period" not "Return the period")
+- Use present tense ("Derives a key" not "Will derive a key")
+- Reference related types with `[SquareBrackets]` KDoc links
+- Keep the first sentence a concise summary (it appears in IDE quick-docs)
+- Use `**bold**` for invariant keywords and scenario labels
+- Prefer `@property` over inline `//` comments for data class fields
+- Remove `//` comments that are superseded by KDoc

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/Insight.kt
@@ -10,14 +10,21 @@ import kotlin.math.roundToInt
 import kotlin.time.ExperimentalTime
 
 /**
- * A sealed interface representing a single piece of generated insight
- * derived from the user's health data.
+ * A single piece of generated insight derived from the user's health data.
+ *
+ * All insight types implement this sealed interface. Insights are deduplicated by [id]
+ * and sorted by [priority] descending before being displayed.
+ *
+ * @property id          Unique identifier for deduplication (e.g., "CYCLE_LENGTH_AVERAGE").
+ * @property title       Short heading shown to the user.
+ * @property description Full explanatory text, possibly with localized dates and numbers.
+ * @property priority    Sort key — higher values appear first. Range: 90 (lowest) to 110 (highest).
  */
 sealed interface Insight {
     val id: String
     val title: String
     val description: String
-    val priority: Int // Used for sorting; higher numbers are more important.
+    val priority: Int
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/InsightEngine.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/InsightEngine.kt
@@ -8,9 +8,27 @@ import com.veleda.cyclewise.domain.models.FullDailyLog
 import com.veleda.cyclewise.domain.models.Symptom
 import kotlinx.datetime.daysUntil
 
+/**
+ * Orchestrates insight generation by running registered [InsightGenerator]s in dependency order.
+ *
+ * Execution proceeds in two phases:
+ * 1. [NextPeriodPredictionGenerator] runs first (other generators may depend on its output).
+ * 2. All remaining generators run with the prediction result available in [InsightData.generatedInsights].
+ *
+ * Results are deduplicated by [Insight.id] and sorted by [Insight.priority] descending.
+ */
 class InsightEngine(
     private val generators: List<InsightGenerator>,
 ) {
+    /**
+     * Generates all insights from the user's data.
+     *
+     * @param allPeriods      all periods, sorted by start date descending.
+     * @param allLogs         all daily logs across all dates.
+     * @param symptomLibrary  the user's full symptom library (for ID-to-name lookups).
+     * @param topSymptomsCount how many top symptoms to include in [TopSymptomsInsight].
+     * @return deduplicated insights sorted by priority descending.
+     */
     fun generateInsights(
         allPeriods: List<Period>,
         allLogs: List<FullDailyLog>,
@@ -19,7 +37,6 @@ class InsightEngine(
     ): List<Insight> {
         val insights = mutableListOf<Insight>()
 
-        // 1. Prepare the initial data.
         val baseData = InsightData(
             allPeriods = allPeriods,
             allLogs = allLogs,
@@ -28,23 +45,25 @@ class InsightEngine(
             topSymptomsCount = topSymptomsCount
         )
 
-        // 2. Run generators that have no dependencies first (like prediction).
-        // This is a simple way to handle dependency order for now.
         val predictionGenerator = generators.find { it is NextPeriodPredictionGenerator }
         predictionGenerator?.let { insights.addAll(it.generate(baseData)) }
 
-        // 3. Prepare data for the next set of generators, now including the prediction.
         val dataWithPrediction = baseData.copy(generatedInsights = insights)
-
-        // 4. Run all other generators.
         generators.filterNot { it is NextPeriodPredictionGenerator }.forEach { generator ->
             insights.addAll(generator.generate(dataWithPrediction))
         }
 
-        // 5. Sort the final list by priority.
         return insights.distinctBy { it.id }.sortedByDescending { it.priority }
     }
 
+    /**
+     * Calculates the average cycle length from completed periods.
+     *
+     * Cycle length is defined as the number of days between consecutive period start dates
+     * (start-to-start). Requires at least 2 completed periods to produce a result.
+     *
+     * @return the average cycle length in days, or null if fewer than 2 completed periods exist.
+     */
     private fun calculateAverageCycleLength(allPeriods: List<Period>): Double? {
         val chronologicalCycles = allPeriods.filter { it.endDate != null }.reversed()
         if (chronologicalCycles.size < 2) return null

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/CycleLengthAverageGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/CycleLengthAverageGenerator.kt
@@ -3,6 +3,10 @@ package com.veleda.cyclewise.domain.insights.generators
 import com.veleda.cyclewise.domain.insights.CycleLengthAverage
 import com.veleda.cyclewise.domain.insights.Insight
 
+/**
+ * Passes through the pre-calculated average cycle length as a [CycleLengthAverage] insight.
+ * Returns an empty list if the average is unavailable (fewer than 2 completed periods).
+ */
 class CycleLengthAverageGenerator : InsightGenerator {
     override fun generate(data: InsightData): List<Insight> {
         return if (data.averageCycleLength != null) {

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/CycleLengthTrendGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/CycleLengthTrendGenerator.kt
@@ -6,6 +6,19 @@ import kotlinx.datetime.daysUntil
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
+/**
+ * Detects whether cycle length is trending longer, shorter, or remaining stable.
+ *
+ * Splits the user's cycle duration history into an older half and a recent half,
+ * compares their averages, and reports the trend.
+ *
+ * ## Minimum Data
+ * Requires at least 6 completed periods (5 inter-cycle durations).
+ *
+ * ## Threshold
+ * A difference of > 1 day between halves is considered a meaningful trend.
+ * Differences <= 1 day are reported as "remained consistent".
+ */
 class CycleLengthTrendGenerator : InsightGenerator {
     override fun generate(data: InsightData): List<Insight> {
         val completedCycles = data.allPeriods.filter { it.endDate != null }.reversed()

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/InsightGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/InsightGenerator.kt
@@ -6,8 +6,19 @@ import com.veleda.cyclewise.domain.models.Symptom
 import com.veleda.cyclewise.domain.insights.Insight
 
 /**
- * A container for all the data an insight generator might need.
- * This simplifies the generator interface.
+ * Immutable snapshot of all data available to insight generators.
+ *
+ * Passed by the [InsightEngine] to each generator. Generators must treat this
+ * as read-only and must not mutate any collections.
+ *
+ * @property allPeriods         All periods, sorted by start date descending.
+ * @property allLogs            All daily logs across all dates.
+ * @property symptomLibrary     The user's symptom library (for ID-to-name resolution).
+ * @property averageCycleLength Pre-calculated average cycle length in days, or null if
+ *                              fewer than 2 completed periods exist.
+ * @property generatedInsights  Insights produced by earlier generators in the pipeline
+ *                              (used for cross-generator dependencies, e.g., prediction date).
+ * @property topSymptomsCount   User-configured limit for the "top symptoms" insight.
  */
 data class InsightData(
     val allPeriods: List<Period>,
@@ -19,8 +30,13 @@ data class InsightData(
 )
 
 /**
- * The contract for any class that can generate insights.
+ * Contract for a class that generates zero or more [Insight]s from user data.
+ *
+ * Implementations must be **pure** — [generate] must not mutate [data] or produce
+ * side effects. Each generator is responsible for its own minimum-data guards
+ * (e.g., returning an empty list when insufficient data exists).
  */
 interface InsightGenerator {
+    /** Produces insights from [data], or an empty list if insufficient data is available. */
     fun generate(data: InsightData): List<Insight>
 }

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/MoodPhasePatternGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/MoodPhasePatternGenerator.kt
@@ -8,6 +8,27 @@ import kotlin.math.abs
 
 private enum class MoodType { LOW, HIGH }
 
+/**
+ * Detects recurring mood-to-cycle-phase correlations across recent cycles.
+ *
+ * Uses the same day-normalization algorithm as [SymptomPhasePatternGenerator]:
+ * days 1-16 are follicular-phase offsets; days > 16 become negative luteal-phase offsets.
+ *
+ * ## Mood Thresholds
+ * - **LOW:** moodScore <= 2
+ * - **HIGH:** moodScore >= 4
+ * - Scores of 3 are excluded (neutral).
+ *
+ * ## Significance Criteria
+ * Same as symptom patterns: >= 3 occurrences AND >= 60% recurrence across analyzed cycles.
+ *
+ * ## Block Detection
+ * Significant days are grouped by proximity (gap <= 2 days). A block must contain
+ * at least 3 individually significant days to produce an insight.
+ *
+ * ## Minimum Data
+ * Requires at least 4 completed periods (3 full cycles).
+ */
 class MoodPhasePatternGenerator : InsightGenerator {
 
     override fun generate(data: InsightData): List<Insight> {
@@ -15,7 +36,6 @@ class MoodPhasePatternGenerator : InsightGenerator {
         if (chronologicalCycles.size < 4) return emptyList()
 
         val cyclePairs = chronologicalCycles.zipWithNext()
-        //val logsByCycleId = data.allLogs.groupBy { it.entry.periodId }
 
         val patternTally = mutableMapOf<Pair<MoodType, Int>, Int>()
 
@@ -74,12 +94,17 @@ class MoodPhasePatternGenerator : InsightGenerator {
     }
 
     /**
-     * Finds all dynamically-sized, non-overlapping, dense clusters of significant days.
+     * Groups significant days into dense, non-overlapping clusters by proximity.
+     *
+     * Days within a gap of <= 2 are merged into the same block. A block is retained
+     * only if it contains at least 3 individually significant days.
+     *
+     * @param significantDays sorted list of normalized day offsets that passed significance filtering.
+     * @return non-overlapping blocks, each containing >= 3 consecutive-ish significant days.
      */
     private fun findAllSignificantBlocks(significantDays: List<Int>): List<List<Int>> {
         if (significantDays.isEmpty()) return emptyList()
 
-        // 1. Group all significant days into blocks based on proximity (gap of <= 2 days).
         val potentialBlocks = mutableListOf<List<Int>>()
         var currentBlock = mutableListOf<Int>()
         for (day in significantDays) {
@@ -92,10 +117,13 @@ class MoodPhasePatternGenerator : InsightGenerator {
         }
         if (currentBlock.isNotEmpty()) potentialBlocks.add(currentBlock)
 
-        // A block is significant if it contains at least 3 individually significant days.
         return potentialBlocks.filter { it.size >= 3 }
     }
 
+    /**
+     * Formats a human-readable phase description for a mood pattern group.
+     * Same phase boundary logic as [SymptomPhasePatternGenerator.formatRelativePhase].
+     */
     private fun formatRelativePhase(group: List<Int>, periods: List<Period>): String {
         if (group.isEmpty()) return ""
 

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/NextPeriodPredictionGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/NextPeriodPredictionGenerator.kt
@@ -11,6 +11,17 @@ import kotlin.math.roundToInt
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+/**
+ * Predicts the start date of the next menstrual period.
+ *
+ * Calculation: `latestPeriod.startDate + averageCycleLength (rounded)`.
+ *
+ * Returns an empty list if the average cycle length is unavailable (fewer than 2 completed
+ * periods) or if no periods exist at all.
+ *
+ * This generator runs first in the [InsightEngine] pipeline so that other generators
+ * (e.g., [SymptomPhasePatternGenerator]) can use its prediction for recurrence forecasting.
+ */
 class NextPeriodPredictionGenerator : InsightGenerator {
     @OptIn(ExperimentalTime::class)
     override fun generate(data: InsightData): List<Insight> {
@@ -23,10 +34,8 @@ class NextPeriodPredictionGenerator : InsightGenerator {
         val averageLengthInDays = data.averageCycleLength.roundToInt()
         val predictedDate = latestCycle.startDate.plus(averageLengthInDays, DateTimeUnit.DAY)
 
-        // Calculate the days until prediction
         val daysUntil = today.daysUntil(predictedDate)
 
-        // Pass the raw date and the calculated daysUntil
         return listOf(NextPeriodPrediction(
             predictedDate = predictedDate,
             daysUntilPrediction = daysUntil

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/SymptomPhasePatternGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/SymptomPhasePatternGenerator.kt
@@ -13,33 +13,59 @@ import kotlin.math.abs
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+/**
+ * Detects recurring symptom-to-cycle-phase correlations across recent cycles.
+ *
+ * ## Algorithm Overview
+ *
+ * 1. **Cycle pairing:** Consecutive completed periods are paired to define cycles.
+ *    Each cycle spans from one period's start to the next period's start.
+ *
+ * 2. **Day normalization:** Each symptom occurrence's `dayInCycle` is normalized to a
+ *    phase-relative offset. Days 1-16 are kept as-is (follicular phase). Days > 16 are
+ *    converted to negative offsets from the next period start (`day - cycleLength - 1`),
+ *    making luteal-phase patterns comparable across variable-length cycles.
+ *
+ * 3. **Pattern tallying:** Symptom occurrences are tallied per `(symptomId, normalizedDay)`
+ *    across the last 8 cycles (via `takeLast(8)`).
+ *
+ * 4. **Significance filtering:** A pattern is significant if it occurs in >= 3 cycles
+ *    AND in >= 60% of analyzed cycles.
+ *
+ * 5. **Grouping:** Significant days for each symptom are grouped into consecutive-day
+ *    clusters. Each cluster produces one [SymptomPhasePattern] insight.
+ *
+ * 6. **Prediction:** If a [NextPeriodPrediction] is available, the generator estimates
+ *    when the symptom will next recur and assigns a probability label.
+ *
+ * ## Priority
+ * - Patterns during the period itself receive [HIGH_PRIORITY] (108).
+ * - Patterns outside the period receive [NORMAL_PRIORITY] (98).
+ *
+ * ## Minimum Data
+ * Requires at least 4 completed periods (3 full cycles).
+ */
 class SymptomPhasePatternGenerator : InsightGenerator {
 
     companion object {
-        private const val HIGH_PRIORITY = 108 // For patterns during the period
-        private const val NORMAL_PRIORITY = 98  // For patterns outside the period
+        private const val HIGH_PRIORITY = 108
+        private const val NORMAL_PRIORITY = 98
     }
 
     @OptIn(ExperimentalTime::class)
     override fun generate(data: InsightData): List<Insight> {
-        // Get all completed, logged periods, sorted from oldest to most recent.
         val chronologicalPeriods = data.allPeriods.filter { it.endDate != null }.reversed()
 
         if (chronologicalPeriods.size < 4) return emptyList()
 
-
-        // This `cyclePairs` list is crucial. Each pair, like `(Period 1, Period 2)`, represents a single, complete menstrual cycle.
-        // The length of this cycle is the time from the start of Period 1 to the start of Period 2.
         val cyclePairs = chronologicalPeriods.zipWithNext()
 
         val patternTally = mutableMapOf<Pair<String, Int>, Int>()
 
-
-        // Iterate through each cycle (defined by the start of two consecutive periods).
+        // Analyze the most recent 8 cycles.
         for ((currentPeriod, nextPeriod) in cyclePairs.takeLast(8)) {
             val actualCycleLength = currentPeriod.startDate.daysUntil(nextPeriod.startDate)
 
-            // Find all logs that fall within the date range of this specific cycle.
             val logsForCycle = data.allLogs.filter {
                 it.entry.entryDate >= currentPeriod.startDate && it.entry.entryDate < nextPeriod.startDate
             }
@@ -48,7 +74,6 @@ class SymptomPhasePatternGenerator : InsightGenerator {
             for (log in logsForCycle) {
                 for (symptomLog in log.symptomLogs) {
                     val day = log.entry.dayInCycle
-                    // The normalization logic remains correct as dayInCycle is still calculated.
                     val normalizedDay = if (day <= 16) day else day - actualCycleLength - 1
                     val key = Pair(symptomLog.symptomId, normalizedDay)
                     patternTally[key] = (patternTally[key] ?: 0) + 1
@@ -65,7 +90,6 @@ class SymptomPhasePatternGenerator : InsightGenerator {
         val patternsBySymptom = significantPatterns.entries.groupBy({ it.key.first }, { it.key.second })
         val resultingInsights = mutableListOf<SymptomPhasePattern>()
 
-        // Calculate the user's average period length to help identify period-related symptoms.
         val avgPeriodLength = data.allPeriods
             .mapNotNull { it.endDate?.let { endDate -> it.startDate.daysUntil(endDate) + 1 } }
             .average()
@@ -124,6 +148,12 @@ class SymptomPhasePatternGenerator : InsightGenerator {
         return resultingInsights
     }
 
+    /**
+     * Groups a sorted list of normalized day offsets into runs of consecutive integers.
+     *
+     * For example, `[1, 2, 3, 7, 8]` becomes `[[1, 2, 3], [7, 8]]`.
+     * Each group represents a contiguous symptom cluster within a cycle phase.
+     */
     private fun groupConsecutiveDays(days: List<Int>): List<List<Int>> {
         if (days.isEmpty()) return emptyList()
         val groups = mutableListOf<MutableList<Int>>()
@@ -135,6 +165,12 @@ class SymptomPhasePatternGenerator : InsightGenerator {
         return groups
     }
 
+    /**
+     * Formats a human-readable phase description for a group of normalized days.
+     *
+     * Period symptoms (all days within average period length) get "on day X of your period".
+     * Non-period symptoms are delegated to [formatRelativePhase] for "X days before/after" phrasing.
+     */
     private fun formatPhaseDescription(group: List<Int>, isPeriodSymptom: Boolean, periods: List<Period>): String {
         if (group.isEmpty()) return ""
 
@@ -149,6 +185,15 @@ class SymptomPhasePatternGenerator : InsightGenerator {
         }
     }
 
+    /**
+     * Formats a relative phase description for non-period symptom groups.
+     *
+     * Uses the representative day (group average) to determine the phase:
+     * - **Luteal phase** (representativeDay > 16 or < 0): "X days before your period"
+     * - **Follicular phase** (representativeDay <= 16): "X days after your period"
+     *
+     * The day-16 boundary approximates the follicular/luteal split in a typical cycle.
+     */
     private fun formatRelativePhase(group: List<Int>, periods: List<Period>): String {
         if (group.isEmpty()) return ""
         val representativeDay = group.average().toInt()

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/SymptomRecurrenceGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/insights/generators/SymptomRecurrenceGenerator.kt
@@ -3,14 +3,22 @@ package com.veleda.cyclewise.domain.insights.generators
 import com.veleda.cyclewise.domain.insights.Insight
 import com.veleda.cyclewise.domain.insights.TopSymptomsInsight
 
+/**
+ * Identifies the user's most frequently logged symptoms across all time.
+ *
+ * Returns a single [TopSymptomsInsight] containing the top N symptom names by occurrence count,
+ * where N is configured by [InsightData.topSymptomsCount].
+ *
+ * ## Minimum Data
+ * Requires at least 10 total symptom log entries to produce a result.
+ */
 class SymptomRecurrenceGenerator : InsightGenerator {
     override fun generate(data: InsightData): List<Insight> {
         val allSymptomLogs = data.allLogs.flatMap { it.symptomLogs }
-        if (allSymptomLogs.size < 10) { // Require at least 10 logs to be meaningful
+        if (allSymptomLogs.size < 10) {
             return emptyList()
         }
 
-        // 1. Get the top X symptom IDs
         val frequentSymptomIds = allSymptomLogs
             .groupingBy { it.symptomId }
             .eachCount()
@@ -19,12 +27,10 @@ class SymptomRecurrenceGenerator : InsightGenerator {
             .take(data.topSymptomsCount)
             .map { it.key }
 
-        // 2. Map the IDs to their names.
         val topSymptomNames = frequentSymptomIds.mapNotNull { symptomId ->
             data.symptomLibrary.find { it.id == symptomId }?.name
         }
 
-        // 3. If we have any results, create a single insight object containing the list.
         return if (topSymptomNames.isNotEmpty()) {
             listOf(TopSymptomsInsight(topSymptomNames))
         } else {

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/DailyEntry.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/DailyEntry.kt
@@ -4,17 +4,36 @@ import kotlinx.datetime.LocalDate
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * A single day's health and wellness entry, linked to a parent period by date proximity.
+ *
+ * Each entry captures subjective ratings, freeform notes, and tags for one calendar day.
+ * The parent period is not stored as a direct FK; instead, [dayInCycle] is calculated
+ * from the nearest preceding period's start date at creation time.
+ *
+ * @property id         UUID primary key.
+ * @property entryDate  Calendar date this entry represents (one entry per date).
+ * @property dayInCycle 1-based offset from the parent period's start date.
+ * @property moodScore  User-rated mood on a 1 (lowest) to 5 (highest) scale, or null if unrecorded.
+ * @property energyLevel User-rated energy on a 1 (lowest) to 5 (highest) scale, or null if unrecorded.
+ * @property libidoLevel Categorical libido rating, or null if unrecorded.
+ * @property customTags Freeform user tags; serialized as a JSON string array in the database.
+ * @property note       Optional free-text note for the day.
+ * @property cyclePhase Computed cycle phase label (e.g., "FOLLICULAR"), or null if unset.
+ * @property createdAt  Timestamp when this entry was first persisted.
+ * @property updatedAt  Timestamp of the most recent modification.
+ */
 @OptIn(ExperimentalTime::class)
 data class DailyEntry(
-    val id: String, // UUID
+    val id: String,
     val entryDate: LocalDate,
     val dayInCycle: Int,
-    val moodScore: Int? = null, // 1-5
-    val energyLevel: Int? = null, // 1-5
-    val libidoLevel: LibidoLevel? = null, // e.g., LibidoLevel.MEDIUM
-    val customTags: List<String> = emptyList(), // For flexible user tags
+    val moodScore: Int? = null,
+    val energyLevel: Int? = null,
+    val libidoLevel: LibidoLevel? = null,
+    val customTags: List<String> = emptyList(),
     val note: String? = null,
-    val cyclePhase: String? = null, // e.g., "FOLLICULAR"
+    val cyclePhase: String? = null,
     val createdAt: Instant,
     val updatedAt: Instant
 )

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/DayDetails.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/DayDetails.kt
@@ -1,9 +1,15 @@
 package com.veleda.cyclewise.domain.models
 
 /**
- * A UI-agnostic domain model that encapsulates the key data points
- * for a single day, derived from underlying cycles and logs.
- * This is the "truth" that the repository provides to the presentation layer.
+ * UI-agnostic summary of a single calendar day's status, derived from periods and logs.
+ *
+ * Emitted by [PeriodRepository.observeDayDetails] as the single source of truth
+ * for the calendar UI. Each flag indicates whether the corresponding data type
+ * has been recorded for this day.
+ *
+ * @property isPeriodDay         True if this date falls within any saved period's date range.
+ * @property hasLoggedSymptoms   True if at least one [SymptomLog] exists for this date.
+ * @property hasLoggedMedications True if at least one [MedicationLog] exists for this date.
  */
 data class DayDetails(
     val isPeriodDay: Boolean = false,

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Enums.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Enums.kt
@@ -1,22 +1,43 @@
 package com.veleda.cyclewise.domain.models
 
+/**
+ * Subjective intensity of menstrual flow for a single day.
+ * Stored in [PeriodLog.flowIntensity] and persisted as the enum name string.
+ */
 enum class FlowIntensity {
+    /** Minimal or spotting-level flow. */
     LIGHT,
+    /** Typical mid-range flow. */
     MEDIUM,
+    /** Notably heavy flow day. */
     HEAVY
 }
 
+/**
+ * Categorical libido self-assessment for a single day.
+ * Stored in [DailyEntry.libidoLevel] and persisted as the enum name string.
+ */
 enum class LibidoLevel {
     LOW,
     MEDIUM,
     HIGH
 }
 
+/**
+ * Broad classification for symptoms in the user's symptom library.
+ * Used to group symptoms in the UI and for phase-pattern analysis.
+ */
 enum class SymptomCategory {
+    /** Physical pain symptoms (cramps, headache, joint pain). */
     PAIN,
+    /** Emotional and mental health symptoms (anxiety, mood swings). */
     MOOD,
+    /** Gastrointestinal symptoms (bloating, nausea, appetite changes). */
     DIGESTIVE,
+    /** Skin-related symptoms (acne, dryness). */
     SKIN,
+    /** Fatigue, brain fog, and sleep-related symptoms. */
     ENERGY,
+    /** Catch-all for user-created symptoms that don't fit other categories. */
     OTHER
 }

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/FullDailyLog.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/FullDailyLog.kt
@@ -1,9 +1,16 @@
 package com.veleda.cyclewise.domain.models
 
 /**
- * A composite data class that holds a DailyEntry and its related
- * symptoms and medicationLogs. This is useful for the UI layer and for
- * ensuring data is saved transactionally.
+ * Composite snapshot of all data recorded for a single day.
+ *
+ * Aggregates a [DailyEntry] with its related flow, symptom, and medication logs.
+ * Used as the unit of transactional save in [PeriodRepository.saveFullLog] and as
+ * the data source for the daily log editing screen.
+ *
+ * @property entry          The core daily entry (mood, energy, tags, notes).
+ * @property periodLog      Flow intensity for this day, or null if no flow was recorded.
+ * @property symptomLogs    Symptoms logged for this day; empty list means none recorded.
+ * @property medicationLogs Medications taken on this day; empty list means none recorded.
  */
 data class FullDailyLog(
     val entry: DailyEntry,

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Medication.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Medication.kt
@@ -3,9 +3,19 @@ package com.veleda.cyclewise.domain.models
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
-// Represents a unique medication in the user's library.
+/**
+ * A unique medication in the user's medication library.
+ *
+ * Each medication is created once and referenced by [MedicationLog] entries.
+ * Names are unique within the library (enforced by a unique index on the entity layer).
+ * No dosage or frequency information is tracked; logs record only that the medication was taken.
+ *
+ * @property id        UUID primary key.
+ * @property name      Human-readable medication name, unique across the library.
+ * @property createdAt Timestamp when this medication was added to the library.
+ */
 data class Medication @OptIn(ExperimentalTime::class) constructor(
-    val id: String, // UUID
+    val id: String,
     val name: String,
     val createdAt: Instant
 )

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/MedicationLog.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/MedicationLog.kt
@@ -3,9 +3,21 @@ package com.veleda.cyclewise.domain.models
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
+/**
+ * Records that a medication was taken on a specific day.
+ *
+ * This is a boolean "taken" record — no dosage or frequency information is stored.
+ * Links a [DailyEntry] to a [Medication] from the user's library.
+ * Multiple [MedicationLog] entries can exist for the same day (one per distinct medication).
+ *
+ * @property id           UUID primary key for this log entry.
+ * @property entryId      FK to the parent [DailyEntry] (CASCADE delete).
+ * @property medicationId FK to the [Medication] library entry (RESTRICT delete).
+ * @property createdAt    Timestamp when this log was recorded.
+ */
 data class MedicationLog @OptIn(ExperimentalTime::class) constructor(
-    val id: String, // UUID
-    val entryId: String, // FK to DailyEntry
+    val id: String,
+    val entryId: String,
     val medicationId: String,
     val createdAt: Instant
 )

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Period.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Period.kt
@@ -5,13 +5,20 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
- * Represents a single period.
+ * Represents a single menstrual period (a contiguous range of period days).
  *
- * @property id        External UUID (TEXT UNIQUE) for this cycle
- * @property startDate The date the cycle began
- * @property endDate   The date the cycle ended (nullable for ongoing cycle)
- * @property createdAt Timestamp when this record was first created
- * @property updatedAt Timestamp of the last update to this record
+ * **Invariant:** [startDate] <= [endDate] when [endDate] is non-null.
+ * A null [endDate] indicates an ongoing (not yet ended) period.
+ *
+ * Periods are sorted by [startDate] descending when returned from [PeriodRepository.getAllPeriods].
+ * The cycle length is measured as the number of days from this period's [startDate] to the
+ * next period's start date.
+ *
+ * @property id        External UUID exposed to the domain and UI layers.
+ * @property startDate The first day of this period.
+ * @property endDate   The last day of this period, or null if the period is still ongoing.
+ * @property createdAt Timestamp when this record was first persisted.
+ * @property updatedAt Timestamp of the most recent modification.
  */
 data class Period @OptIn(ExperimentalTime::class) constructor(
     val id: String,

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/PeriodLog.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/PeriodLog.kt
@@ -4,13 +4,25 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
- * Represents the flow attributes recorded for a single day,
- * decoupled from the core DailyEntry model.
+ * Records the menstrual flow attributes for a single day, decoupled from [DailyEntry].
+ *
+ * A [PeriodLog] exists only for days where flow was actively recorded. Its presence
+ * indicates the day is a period day; its absence means no flow was logged (even if the
+ * date falls within a [Period]'s date range).
+ *
+ * **Invariant:** [flowIntensity] is always non-null — if no flow is recorded, the
+ * entire [PeriodLog] is deleted rather than storing a null intensity.
+ *
+ * @property id            UUID primary key for this flow record.
+ * @property entryId       FK to the parent [DailyEntry] for this day (CASCADE delete).
+ * @property flowIntensity The subjective flow level for this day.
+ * @property createdAt     Timestamp when this record was first persisted.
+ * @property updatedAt     Timestamp of the most recent modification.
  */
 data class PeriodLog @OptIn(ExperimentalTime::class) constructor(
-    val id: String, // UUID for this flow record
-    val entryId: String, // FK to the DailyEntry for this day
-    val flowIntensity: FlowIntensity, // Must be non-null if this log exists
+    val id: String,
+    val entryId: String,
+    val flowIntensity: FlowIntensity,
     val createdAt: Instant,
     val updatedAt: Instant
 )

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Symptom.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/Symptom.kt
@@ -4,10 +4,18 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
- * Represents a unique symptom type in the user's library.
+ * A unique symptom type in the user's symptom library.
+ *
+ * Each symptom is created once and referenced by [SymptomLog] entries.
+ * Names are unique within the library (enforced by a unique index on the entity layer).
+ *
+ * @property id        UUID primary key.
+ * @property name      Human-readable symptom name, unique across the library.
+ * @property category  Broad classification for UI grouping and analysis.
+ * @property createdAt Timestamp when this symptom was added to the library.
  */
 data class Symptom @OptIn(ExperimentalTime::class) constructor(
-    val id: String, // UUID
+    val id: String,
     val name: String,
     val category: SymptomCategory,
     val createdAt: Instant

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/SymptomLog.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/SymptomLog.kt
@@ -4,12 +4,21 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
- * Represents an instance of experiencing a symptom, linked to a DailyEntry and a Symptom.
+ * Records a single occurrence of a symptom on a specific day.
+ *
+ * Links a [DailyEntry] to a [Symptom] from the user's library with a severity rating.
+ * Multiple [SymptomLog] entries can exist for the same day (one per distinct symptom).
+ *
+ * @property id        UUID primary key for this log entry.
+ * @property entryId   FK to the parent [DailyEntry] (CASCADE delete).
+ * @property symptomId FK to the [Symptom] library entry (RESTRICT delete).
+ * @property severity  User-rated severity on a 1 (mild) to 5 (severe) scale.
+ * @property createdAt Timestamp when this log was recorded.
  */
 data class SymptomLog @OptIn(ExperimentalTime::class) constructor(
-    val id: String, // UUID of the log entry itself
-    val entryId: String, // FK to DailyEntry
-    val symptomId: String, // FK to the Symptom library entry
-    val severity: Int, // 1-5
+    val id: String,
+    val entryId: String,
+    val symptomId: String,
+    val severity: Int,
     val createdAt: Instant
 )

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/WaterIntake.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/WaterIntake.kt
@@ -5,8 +5,16 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
- * Represents a single day's water intake record.
- * Uses [date] as the natural key (one row per day).
+ * A single day's water intake record.
+ *
+ * Uses [date] as the natural primary key (one row per day, upsert semantics).
+ * Water tracking is available both on the lock screen (via [LockedWaterDraft])
+ * and the daily log screen; drafts are synced into the encrypted database on unlock.
+ *
+ * @property date      Calendar date this record represents (PK, ISO-8601 string in DB).
+ * @property cups      Number of cups logged for this day (non-negative).
+ * @property createdAt Timestamp when this record was first persisted.
+ * @property updatedAt Timestamp of the most recent modification.
  */
 data class WaterIntake @OptIn(ExperimentalTime::class) constructor(
     val date: LocalDate,

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/providers/MedicationLibraryProvider.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/providers/MedicationLibraryProvider.kt
@@ -5,8 +5,13 @@ import com.veleda.cyclewise.domain.repository.PeriodRepository
 import kotlinx.coroutines.flow.Flow
 
 /**
- * A session-scoped provider that acts as the single source of truth
- * for the user's entire medication library.
+ * Session-scoped provider exposing the user's medication library as a reactive stream.
+ *
+ * Acts as the single source of truth for medication types across all screens.
+ * Created when the session scope opens (after passphrase unlock) and destroyed on logout.
+ *
+ * @property medications Cold [Flow] of the full medication library, sorted by name ascending.
+ *                       Emits the current snapshot on subscription and updates on any library change.
  */
 class MedicationLibraryProvider(private val periodRepository: PeriodRepository) {
     val medications: Flow<List<Medication>> = periodRepository.getMedicationLibrary()

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/providers/SymptomLibraryProvider.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/providers/SymptomLibraryProvider.kt
@@ -5,8 +5,13 @@ import com.veleda.cyclewise.domain.repository.PeriodRepository
 import kotlinx.coroutines.flow.Flow
 
 /**
- * A session-scoped provider that acts as the single source of truth
- * for the user's entire symptom library.
+ * Session-scoped provider exposing the user's symptom library as a reactive stream.
+ *
+ * Acts as the single source of truth for symptom types across all screens.
+ * Created when the session scope opens (after passphrase unlock) and destroyed on logout.
+ *
+ * @property symptoms Cold [Flow] of the full symptom library, sorted by name ascending.
+ *                    Emits the current snapshot on subscription and updates on any library change.
  */
 class SymptomLibraryProvider(private val periodRepository: PeriodRepository) {
     val symptoms: Flow<List<Symptom>> = periodRepository.getSymptomLibrary()

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/repository/PeriodRepository.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/repository/PeriodRepository.kt
@@ -14,99 +14,210 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.YearMonth
 
 /**
- * Shared interface for accessing and modifying period data.
- * Platform-specific implementations will handle persistence.
+ * Central contract for all period, daily log, library, and water intake data access.
+ *
+ * Platform-specific implementations (e.g., [RoomPeriodRepository]) handle persistence.
+ * All [Flow]-returning methods emit cold streams — subscribers receive the current snapshot
+ * on subscription and subsequent updates whenever the underlying data changes.
+ * All `suspend` methods are safe to call from any dispatcher (Room handles IO internally).
  */
 interface PeriodRepository {
 
-    /** Returns all known periods, sorted by start date descending. */
+    // ── Period CRUD ──────────────────────────────────────────────────────
+
+    /**
+     * Returns all known periods as a reactive stream, sorted by start date **descending**
+     * (most recent first).
+     */
     fun getAllPeriods(): Flow<List<Period>>
 
-    /** Returns a single period given its primary Id. */
+    /**
+     * Returns a single period by its UUID.
+     *
+     * @throws NoSuchElementException if no period with [periodId] exists.
+     */
     suspend fun getPeriodById(periodId: String): Period
 
-    /** Starts a new period on the given start date. */
+    /**
+     * Creates and persists a new ongoing period (endDate = null) starting on [startDate].
+     *
+     * @return the newly created [Period].
+     */
     suspend fun startNewPeriod(startDate: LocalDate): Period
 
-    /** Updates the end date of an existing period. Can be null to make it ongoing. */
+    /**
+     * Updates the end date of the period identified by [periodId].
+     *
+     * Pass null for [endDate] to reopen the period as ongoing.
+     *
+     * @return the updated [Period], or null if no period with [periodId] exists.
+     */
     suspend fun updatePeriodEndDate(periodId: String, endDate: LocalDate?): Period?
 
-    /** Marks an existing period as ended on the given date. */
+    /**
+     * Marks the period identified by [periodId] as ended on [endDate].
+     *
+     * @return the updated [Period], or null if no period with [periodId] exists.
+     */
     suspend fun endPeriod(periodId: String, endDate: LocalDate): Period?
 
-    /** Returns the currently active (non-ended) period, if any. */
+    /**
+     * Returns the currently ongoing period (endDate == null), or null if none exists.
+     * At most one ongoing period should exist at any time.
+     */
     suspend fun getCurrentlyOngoingPeriod(): Period?
 
-    /** Returns the full daily log for a specific date, or null if none exists. */
-    suspend fun getFullLogForDate(date: LocalDate): FullDailyLog?
-
-    /** Store all data for a day. */
-    suspend fun saveFullLog(log: FullDailyLog)
-
-    /** Fetches all full daily logs for a given month. */
-    suspend fun getLogsForMonth(yearMonth: YearMonth): List<FullDailyLog>
-
-    /** Creates a new, already-completed period in the database. */
+    /**
+     * Creates a new already-completed period with both start and end dates set.
+     *
+     * @return the newly created [Period].
+     */
     suspend fun createCompletedPeriod(startDate: LocalDate, endDate: LocalDate): Period
 
-    /** Checks if a given date range overlaps with any existing periods. */
+    /**
+     * Checks whether [startDate]..[endDate] overlaps with any existing period.
+     *
+     * @return true if the range is free of overlap.
+     */
     suspend fun isDateRangeAvailable(startDate: LocalDate, endDate: LocalDate): Boolean
 
-    /** Returns a reactive Flow of all unique medications in the user's library. */
-    fun getMedicationLibrary(): Flow<List<Medication>>
+    /**
+     * Permanently deletes the period identified by [id] and its associated period logs.
+     * Daily entries and their symptom/medication logs are preserved.
+     */
+    suspend fun deletePeriod(id: String)
+
+    // ── Period Day Marking (State Machine) ───────────────────────────────
 
     /**
-     * Creates a new unique medication in the library if it doesn't already exist by name,
-     * then returns the Medication object (either the new one or the existing one).
+     * Marks [date] as a period day, merging or extending adjacent periods as needed.
+     *
+     * Runs inside a database transaction. Handles four scenarios:
+     * 1. **Already inside a period** — ensures a [PeriodLog] exists for the date.
+     * 2. **Bridges two periods** — merges the day-before and day-after periods into one.
+     * 3. **Extends a period** — adjusts the neighboring period's start or end date.
+     * 4. **Island day** — creates a new single-day completed period.
      */
-    suspend fun createOrGetMedicationInLibrary(name: String): Medication
-
-    /** Returns a reactive Flow of all unique symptoms in the user's library. */
-    fun getSymptomLibrary(): Flow<List<Symptom>>
+    suspend fun logPeriodDay(date: LocalDate)
 
     /**
-     * Creates a new unique symptom in the library if it doesn't already exist by name,
-     * then returns the Symptom object (either the new one or the existing one).
+     * Unmarks [date] as a period day, splitting or shrinking the containing period.
+     *
+     * Runs inside a database transaction. Handles four scenarios:
+     * 1. **Single-day period** — deletes the entire period.
+     * 2. **Start date** — advances the period's start date by one day.
+     * 3. **End date** — retracts the period's end date by one day.
+     * 4. **Middle day** — splits the period into two around the removed date.
+     *
+     * Also deletes any [PeriodLog] for the date.
      */
-    suspend fun createOrGetSymptomInLibrary(name: String, category: SymptomCategory = SymptomCategory.OTHER): Symptom
+    suspend fun unLogPeriodDay(date: LocalDate)
 
-    /** Pre-populates the symptom library with a default set of symptoms. */
-    suspend fun prepopulateSymptomLibrary()
+    // ── Daily Log Access ─────────────────────────────────────────────────
 
-    /** Returns a reactive Flow of ALL daily logs that have been created. */
+    /**
+     * Returns the full daily log for [date], or null if no entry exists for that date.
+     */
+    suspend fun getFullLogForDate(date: LocalDate): FullDailyLog?
+
+    /**
+     * Persists all data for a single day in a transaction.
+     *
+     * Uses delete-then-insert semantics for period logs, symptom logs, and medication logs:
+     * existing child records for the day are removed before the new set is inserted.
+     */
+    suspend fun saveFullLog(log: FullDailyLog)
+
+    /**
+     * Returns all full daily logs whose entry dates fall within [yearMonth].
+     */
+    suspend fun getLogsForMonth(yearMonth: YearMonth): List<FullDailyLog>
+
+    /**
+     * Returns a reactive stream of all daily logs across all dates.
+     * Each emission is a complete snapshot including period logs, symptom logs, and medication logs.
+     */
     fun getAllLogs(): Flow<List<FullDailyLog>>
 
-    /** Emits the set of all LocalDates that are part of any saved menstrual period. */
+    // ── Calendar Observation ─────────────────────────────────────────────
+
+    /**
+     * Emits the set of all [LocalDate]s that fall within any saved period's date range.
+     * Ongoing periods extend through today.
+     */
     fun observeAllPeriodDays(): Flow<Set<LocalDate>>
 
     /**
-     * Observes all underlying data sources (Periods, logs, etc.) and emits a consolidated
-     * map of details for each relevant day, using a UI-agnostic domain model.
-     * This is the single source of truth for the calendar UI.
+     * Emits a consolidated map of [DayDetails] for every day with recorded data.
+     *
+     * Combines period date ranges, symptom logs, and medication logs into a single
+     * map keyed by date. This is the **single source of truth** for the calendar UI.
      */
     fun observeDayDetails(): Flow<Map<LocalDate, DayDetails>>
 
-    /** Fetches a one-shot list of all symptom logs. */
+    // ── Symptom Library ──────────────────────────────────────────────────
+
+    /**
+     * Returns a reactive stream of all symptoms in the library, sorted by name ascending.
+     */
+    fun getSymptomLibrary(): Flow<List<Symptom>>
+
+    /**
+     * Returns the existing symptom with [name], or creates a new one if none exists.
+     *
+     * Name matching is case-sensitive. The [category] parameter is only used when
+     * creating a new symptom.
+     *
+     * @return the existing or newly created [Symptom].
+     */
+    suspend fun createOrGetSymptomInLibrary(name: String, category: SymptomCategory = SymptomCategory.OTHER): Symptom
+
+    /**
+     * Seeds the symptom library with a default set of common symptoms (20 entries).
+     * Uses INSERT IGNORE semantics so existing symptoms are not duplicated.
+     */
+    suspend fun prepopulateSymptomLibrary()
+
+    /** Returns a one-shot list of all [SymptomLog] entries across all dates. */
     suspend fun getAllSymptomLogs(): List<SymptomLog>
 
-    /** Fetches a one-shot list of all medication logs. */
+    // ── Medication Library ───────────────────────────────────────────────
+
+    /**
+     * Returns a reactive stream of all medications in the library, sorted by name ascending.
+     */
+    fun getMedicationLibrary(): Flow<List<Medication>>
+
+    /**
+     * Returns the existing medication with [name], or creates a new one if none exists.
+     *
+     * @return the existing or newly created [Medication].
+     */
+    suspend fun createOrGetMedicationInLibrary(name: String): Medication
+
+    /** Returns a one-shot list of all [MedicationLog] entries across all dates. */
     suspend fun getAllMedicationLogs(): List<MedicationLog>
 
-    /** [DEBUG ONLY] Clears and seeds the database with test data. */
-    suspend fun seedDatabaseForDebug()
+    // ── Water Intake ─────────────────────────────────────────────────────
 
-    /** Permanently deletes a period. */
-    suspend fun deletePeriod(id: String)
-
-    /** Marks a specific date as a period day, merging or extending adjacent periods if necessary. */
-    suspend fun logPeriodDay(date: LocalDate)
-
-    /** Unmarks a specific date as a period day, splitting the existing period or deleting a 1-day period. */
-    suspend fun unLogPeriodDay(date: LocalDate)
-
-    /** Inserts or replaces a water intake record for a given date. */
+    /**
+     * Inserts or replaces the water intake record for [intake]'s date (upsert semantics).
+     */
     suspend fun upsertWaterIntake(intake: WaterIntake)
 
-    /** Returns water intake records for the specified dates. */
+    /**
+     * Returns water intake records for the specified [dates].
+     * Dates with no record are omitted from the result.
+     */
     suspend fun getWaterIntakeForDates(dates: List<LocalDate>): List<WaterIntake>
+
+    // ── Debug ────────────────────────────────────────────────────────────
+
+    /**
+     * **[DEBUG ONLY]** Deletes all user data and seeds the database with several months
+     * of generated cycles, daily logs, symptoms, and medications.
+     *
+     * **Destructive:** all existing data is permanently lost.
+     */
+    suspend fun seedDatabaseForDebug()
 }

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/services/PassPhraseService.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/services/PassPhraseService.kt
@@ -1,13 +1,23 @@
 package com.veleda.cyclewise.domain.services
 
 /**
- * Derives a 256-bit encryption key from the user’s passphrase.
- * The returned ByteArray will be used to construct the SQLCipher SupportFactory.
+ * Derives a 256-bit AES-GCM encryption key from the user's passphrase using a KDF.
+ *
+ * The Android implementation uses Argon2id with a stable per-device salt.
+ * The returned [ByteArray] is passed to SQLCipher's [SupportFactory] to open
+ * the encrypted database.
+ *
+ * **Security contract:**
+ * - The derived key must never be persisted to disk.
+ * - Callers must zeroize the returned [ByteArray] when the session scope closes.
+ * - The KDF must be computationally expensive to resist brute-force attacks.
  */
 interface PassphraseService {
     /**
-     * @param passphrase the user-entered secret
-     * @return a 32-byte (256-bit) key
+     * Derives a 32-byte (256-bit) encryption key from [passphrase].
+     *
+     * @param passphrase the user-entered secret.
+     * @return a 32-byte key suitable for SQLCipher AES-256 encryption.
      */
     fun deriveKey(passphrase: String): ByteArray
 }

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/AutoCloseOngoingPeriodUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/AutoCloseOngoingPeriodUseCase.kt
@@ -12,8 +12,14 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 /**
- * Automatically checks the ongoing period and closes it if there is a 1-day gap
- * since the last recorded period day.
+ * Automatically closes the ongoing period when a 1-day gap is detected.
+ *
+ * Triggered by [TrackerEvent.ScreenEntered] each time the tracker screen appears.
+ * Compares today's date against the last logged period day within the ongoing period.
+ * If the day after the last logged day is today or earlier, the period is closed with
+ * its end date set to the last logged day.
+ *
+ * **No-op** when no ongoing period exists or when the last logged day is today.
  */
 class AutoCloseOngoingPeriodUseCase(
     private val repository: PeriodRepository

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/DebugSeederUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/DebugSeederUseCase.kt
@@ -3,12 +3,14 @@ package com.veleda.cyclewise.domain.usecases
 import com.veleda.cyclewise.domain.repository.PeriodRepository
 
 /**
- * A developer-only use case to seed the database with realistic test data.
+ * **Developer-only** use case that seeds the database with realistic test data.
+ *
+ * **Destructive:** invoking this permanently deletes all existing user data before
+ * inserting generated cycles, daily logs, symptoms, and medications.
  */
 class DebugSeederUseCase(private val periodRepository: PeriodRepository) {
     /**
-     * Deletes all existing user data and seeds the database with several
-     * months of generated cycles and daily logs.
+     * Wipes all data and inserts 6 completed periods with daily entries spanning several months.
      */
     suspend operator fun invoke() {
         periodRepository.seedDatabaseForDebug()

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/EndPeriodUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/EndPeriodUseCase.kt
@@ -3,13 +3,20 @@ package com.veleda.cyclewise.domain.usecases
 import com.veleda.cyclewise.domain.repository.PeriodRepository
 import kotlinx.datetime.LocalDate
 
+/**
+ * Ends a menstrual period by setting its end date.
+ *
+ * Supports two modes:
+ * - **Explicit:** Pass a [periodId] to end a specific period.
+ * - **Auto-find:** Pass null for [periodId] to end the currently ongoing period (if any).
+ */
 class EndPeriodUseCase(
     private val repository: PeriodRepository
 ) {
     /**
-     * End the ongoing cycle (or a specific one) at [endDate].
-     * If [periodId] is null, it will end the currently ongoing cycle if present.
-     * @return the updated cycle, or null if nothing to end.
+     * @param endDate   the date to set as the period's end date.
+     * @param periodId  UUID of the period to end, or null to auto-find the ongoing period.
+     * @return the updated [Period], or null if no matching period was found.
      */
     suspend operator fun invoke(endDate: LocalDate, periodId: String? = null) =
         if (periodId != null) repository.endPeriod(periodId, endDate)

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/GetOrCreateDailyLogUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/GetOrCreateDailyLogUseCase.kt
@@ -12,7 +12,14 @@ import kotlin.time.ExperimentalTime
 
 /**
  * Retrieves an existing [FullDailyLog] for the given date, or creates a new blank one
- * if a parent period exists. Returns null when no period context is available.
+ * if a parent period exists.
+ *
+ * Parent period lookup: finds the first period (sorted by start date descending) whose
+ * start date is on or before [date]. The [DailyEntry.dayInCycle] is calculated as
+ * `parentPeriod.startDate.daysUntil(date) + 1` (1-based).
+ *
+ * @return the existing or newly created [FullDailyLog], or null if no parent period
+ *         contains or precedes [date].
  */
 @OptIn(ExperimentalTime::class)
 class GetOrCreateDailyLogUseCase(

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/StartNewPeriodUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/usecases/StartNewPeriodUseCase.kt
@@ -8,14 +8,19 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 /**
- * Starts a new menstrual period at the given [startDate].
- * Fails if there's already an ongoing period.
+ * Starts a new menstrual period beginning on [startDate].
+ *
+ * **Precondition:** No ongoing period exists (endDate == null).
+ * **Postcondition:** A new [Period] with null endDate is persisted.
+ *
+ * This operation is **not idempotent** — calling it twice while no ongoing period
+ * exists would create two distinct periods (though the second call would fail
+ * because the first would still be ongoing).
  */
 class StartNewPeriodUseCase (private val repository: PeriodRepository)
 {
     /**
-     * Attempts to start a new period.
-     * @return the new period, or null if a period is already ongoing
+     * @return the newly created [Period], or null if an ongoing period already exists.
      */
     @OptIn(ExperimentalTime::class)
     suspend operator fun invoke(startDate: LocalDate): Period? {


### PR DESCRIPTION
 Systematically document ~70 production source files with KDoc that explains
 intent, contracts, and invariants rather than restating code.

 Shared domain layer:
  - Domain models: class-level KDoc + @property for DailyEntry, Period, Symptom, Medication, PeriodLog, SymptomLog, MedicationLog, FullDailyLog, DayDetails, WaterIntake, Enums (FlowIntensity, LibidoLevel, SymptomCategory)
  - PeriodRepository: full overhaul with @param/@return for all 25 methods, 4-scenario state machine docs for logPeriodDay/unLogPeriodDay
  - Use cases: preconditions, postconditions, idempotency contracts
  - InsightEngine: two-phase execution, deduplication, priority sorting
  - Generators: algorithm overviews with magic numbers documented (SymptomPhasePatternGenerator day-16 boundary, 0.60 threshold, takeLast(8); MoodPhasePatternGenerator mood thresholds; CycleLengthTrendGenerator 6-period minimum)
  - Services/providers: security contracts, Flow semantics

  Android data layer:
  - 8 DAOs: table ownership, conflict strategies, FK relationships
  - 8 entities: column formats, FK cascade/restrict semantics
  - Converters: serialization format details
  - Mappers: file-level purpose, id=0 auto-generation pattern
  - PeriodDatabase: SQLCipher security contract, passphrase zeroization
  - 8 migrations: schema change descriptions
  - LockedWaterDraft: auto-prune, rollover, max cups

  UI/infrastructure layer:
  - ViewModels: MVI pattern, init flows, effect semantics, session scope
  - AppModule: two-lifetime DI architecture (singleton vs session)
  - AppSettings: DataStore preference defaults
  - Security services: Argon2id parameters, salt storage

  Consistency sweep:
  - Remove ~17 inline comments superseded by KDoc
  - Create docs/architecture/DOCUMENTATION_GUIDELINES.md

  No production behavior changes.

  Signed-off-by: Daniel Simmons SmileyBob72801@gmail.com