### PR TITLE
fix(security): remediate pre-open-source security audit findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 nul
+
+# Signing keys and credentials
+*.jks
+*.keystore
+*.p12
+*.pem
+*.env
+.env.*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,6 @@ abstract class ExportProjectAsMarkdown : DefaultTask() {
                 out.appendText("```\n$content\n```\n", StandardCharsets.UTF_8)
             }
         }
-        println("Wrote: ${out.absolutePath}")
     }
 
     private fun languageFor(name: String): String {

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:name="com.veleda.cyclewise.CycleWiseApp"

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/MainActivity.kt
@@ -2,6 +2,7 @@ package com.veleda.cyclewise
 
 import android.os.Bundle
 import android.util.Log
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -14,9 +15,13 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
+
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             Log.e("GlobalCrashHandler", "Uncaught exception in ${thread.name}", throwable)
-            throwable.printStackTrace()
         }
 
         setContent {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
@@ -1,6 +1,7 @@
 package com.veleda.cyclewise.di
 
 import com.veleda.cyclewise.androidData.local.draft.LockedWaterDraft
+import android.content.Context
 import com.veleda.cyclewise.domain.repository.PeriodRepository
 import com.veleda.cyclewise.services.SaltStorage
 import com.veleda.cyclewise.ui.auth.WaterTrackerViewModel
@@ -41,6 +42,31 @@ import org.koin.core.qualifier.Qualifier
  * use cases, library providers, and session-bound ViewModels.
  */
 val SESSION_SCOPE: Qualifier = named("UnlockedSessionScope")
+
+/**
+ * Creates the encrypted [PeriodDatabase] and zeroizes the derived key immediately afterward.
+ *
+ * Uses `try/finally` to guarantee the key [ByteArray] is filled with zeros even if
+ * [PeriodDatabase.create] throws, fulfilling the security contract documented at
+ * [PeriodDatabase.create].
+ *
+ * @param context          application context for Room.
+ * @param passphraseService service that derives the 32-byte AES key.
+ * @param passphrase       the user-entered secret.
+ * @return the opened [PeriodDatabase].
+ */
+internal fun createDatabaseAndZeroizeKey(
+    context: Context,
+    passphraseService: PassphraseService,
+    passphrase: String
+): PeriodDatabase {
+    val key = passphraseService.deriveKey(passphrase)
+    return try {
+        PeriodDatabase.create(context, key)
+    } finally {
+        key.fill(0)
+    }
+}
 
 /**
  * Root Koin module defining two DI lifetimes:
@@ -84,8 +110,7 @@ val appModule = module {
     scope(SESSION_SCOPE) {
         // DB Provider
         scoped { (passphrase: String) ->
-            val key = get<PassphraseService>().deriveKey(passphrase)
-            PeriodDatabase.create(androidContext(), key)
+            createDatabaseAndZeroizeKey(androidContext(), get(), passphrase)
         }
 
         // DAO Providers

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
@@ -82,7 +82,7 @@ class PassphraseViewModel(
                 _effect.emit(PassphraseEffect.NavigateToTracker)
 
             } catch (e: Exception) {
-                Log.e("PassphraseUnlock", "Unlock failed with exception", e)
+                Log.e("PassphraseUnlock", "Unlock failed: ${e.message}")
                 getKoin().getScopeOrNull("session")?.close()
                 _effect.emit(PassphraseEffect.ShowError("Failed to unlock. Wrong passphrase?"))
             } finally {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/WaterDraftSyncer.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/WaterDraftSyncer.kt
@@ -48,7 +48,7 @@ class WaterDraftSyncer(
                 }
                 syncedDates += date
             } catch (e: Exception) {
-                Log.e("WaterSync", "Failed to sync water for $date", e)
+                Log.e("WaterSync", "Failed to sync water for $date: ${e.message}")
             }
         }
 

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/security/KeyZeroizationTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/security/KeyZeroizationTest.kt
@@ -1,0 +1,79 @@
+package com.veleda.cyclewise.security
+
+import android.content.Context
+import com.veleda.cyclewise.androidData.local.database.PeriodDatabase
+import com.veleda.cyclewise.di.createDatabaseAndZeroizeKey
+import com.veleda.cyclewise.domain.services.PassphraseService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that [createDatabaseAndZeroizeKey] zeroizes the derived key after database creation.
+ *
+ * The passphrase-derived key must never linger in memory after the database is opened.
+ * These tests confirm the `try/finally` zeroization contract on both the success and
+ * failure paths.
+ */
+class KeyZeroizationTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val passphraseService: PassphraseService = mockk()
+    private val mockDb: PeriodDatabase = mockk(relaxed = true)
+
+    private lateinit var capturedKey: ByteArray
+
+    @Before
+    fun setUp() {
+        capturedKey = ByteArray(32) { 0xFF.toByte() }
+        every { passphraseService.deriveKey(any()) } returns capturedKey
+        mockkObject(PeriodDatabase.Companion)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(PeriodDatabase.Companion)
+    }
+
+    @Test
+    fun createDatabaseAndZeroizeKey_WHEN_createSucceeds_THEN_keyIsZeroized() {
+        // GIVEN create() returns successfully
+        every { PeriodDatabase.create(any(), any(), any()) } returns mockDb
+
+        // WHEN we create the database
+        val db = createDatabaseAndZeroizeKey(context, passphraseService, "test-passphrase")
+
+        // THEN the database is returned
+        assertEquals(mockDb, db)
+
+        // AND every byte of the key is zeroed
+        assertTrue(
+            capturedKey.all { it == 0.toByte() },
+            "Key must be zeroized after successful database creation"
+        )
+    }
+
+    @Test
+    fun createDatabaseAndZeroizeKey_WHEN_createThrows_THEN_keyIsStillZeroized() {
+        // GIVEN create() throws an exception
+        every { PeriodDatabase.create(any(), any(), any()) } throws RuntimeException("DB creation failed")
+
+        // WHEN we attempt to create the database
+        assertFailsWith<RuntimeException>("DB creation failed") {
+            createDatabaseAndZeroizeKey(context, passphraseService, "test-passphrase")
+        }
+
+        // THEN the key is still zeroized despite the failure
+        assertTrue(
+            capturedKey.all { it == 0.toByte() },
+            "Key must be zeroized even when database creation fails"
+        )
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/security/ManifestPermissionTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/security/ManifestPermissionTest.kt
@@ -1,0 +1,40 @@
+package com.veleda.cyclewise.security
+
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertFalse
+
+/**
+ * Verifies that the merged AndroidManifest does not declare the INTERNET permission.
+ *
+ * RhythmWise is a privacy-first, offline-only app — no network access is permitted.
+ * This test guards against accidental re-introduction of the permission via manifest
+ * merging or dependency changes.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class ManifestPermissionTest {
+
+    @Test
+    fun mergedManifest_WHEN_checked_THEN_doesNotDeclareInternetPermission() {
+        // GIVEN the app's merged manifest loaded by Robolectric
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val packageInfo = context.packageManager.getPackageInfo(
+            context.packageName,
+            PackageManager.GET_PERMISSIONS
+        )
+
+        // WHEN we inspect the requested permissions
+        val permissions = packageInfo.requestedPermissions?.toList() ?: emptyList()
+
+        // THEN INTERNET is not among them
+        assertFalse(
+            permissions.contains("android.permission.INTERNET"),
+            "INTERNET permission must not be declared — the app is offline-only"
+        )
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/auth/WaterSyncTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/auth/WaterSyncTest.kt
@@ -29,6 +29,7 @@ class WaterSyncTest {
     @Before
     fun setUp() {
         mockkStatic(Log::class)
+        every { Log.e(any(), any()) } returns 0
         every { Log.e(any(), any(), any()) } returns 0
     }
 

--- a/docs/DeveloperOnboarding.md
+++ b/docs/DeveloperOnboarding.md
@@ -531,9 +531,26 @@ fun getOrCreateSalt(): ByteArray {
 
 ### Security Invariant
 
-The passphrase and derived key **never persist to disk**. They exist only in memory
-during the session scope's lifetime. When the session scope is destroyed (logout,
-autolock, or app termination), the key becomes eligible for garbage collection.
+The passphrase and derived key **never persist to disk**. The derived key is
+**actively zeroized** (`fill(0)`) immediately after the database is opened via
+`createDatabaseAndZeroizeKey()` in `AppModule.kt`. A `try/finally` block
+guarantees zeroization even if `PeriodDatabase.create()` throws:
+
+```kotlin
+// di/AppModule.kt
+internal fun createDatabaseAndZeroizeKey(
+    context: Context,
+    passphraseService: PassphraseService,
+    passphrase: String
+): PeriodDatabase {
+    val key = passphraseService.deriveKey(passphrase)
+    return try {
+        PeriodDatabase.create(context, key)
+    } finally {
+        key.fill(0)   // zeroize on both success and failure
+    }
+}
+```
 
 The `PassphraseService` interface documents this contract explicitly:
 
@@ -719,6 +736,8 @@ RhythmWise is a **single-activity** Compose application. The launch sequence:
 
 2. **`MainActivity`** (`MainActivity.kt`) — Intentionally minimal:
    - Calls `enableEdgeToEdge()` for fullscreen content behind system bars
+   - Sets `FLAG_SECURE` on the window — blocks screenshots, screen recording,
+     and recent-apps thumbnails across all screens
    - Registers a global uncaught exception handler for crash logging
    - Calls `setContent { CycleWiseAppUI() }` — all Compose UI starts here
 
@@ -886,7 +905,7 @@ The UI observes this effect and navigates, popping Passphrase from the backstack
 
 ```kotlin
 } catch (e: Exception) {                                          // line 84
-    Log.e("PassphraseUnlock", "Unlock failed with exception", e)
+    Log.e("PassphraseUnlock", "Unlock failed: ${e.message}")
     getKoin().getScopeOrNull("session")?.close()                  // line 86
     _effect.emit(PassphraseEffect.ShowError(
         "Failed to unlock. Wrong passphrase?"                     // line 87
@@ -2076,6 +2095,28 @@ Log.d("Debug", "Key: ${key.toHex()}")
 Log.d("Debug", "Key derivation complete, length=${key.size}")
 ```
 
+### Never Log Stack Traces in Production
+
+Pass only the message, never the full `Throwable`. Stack traces can leak class names,
+file paths, and internal state into logcat where other apps or USB debugging can
+read them.
+
+```kotlin
+// BAD — full stack trace visible in logcat
+Log.e("Tag", "Operation failed", exception)
+exception.printStackTrace()
+
+// GOOD — message only, no internal structure exposed
+Log.e("Tag", "Operation failed: ${exception.message}")
+```
+
+The global crash handler in `MainActivity` is the **only** place that logs a full
+`Throwable` (to capture otherwise-unrecoverable crash context). All other catch
+blocks must use the message-only form.
+
+Gradle build scripts must not use `println()` for diagnostic output — it leaks
+file paths and build internals into CI logs.
+
 ### Never Persist the Passphrase or Key
 
 The passphrase and derived key must only exist in local variables during the unlock
@@ -2094,6 +2135,35 @@ throw IllegalStateException("Failed to open DB with key: ${key.contentToString()
 // GOOD
 throw IllegalStateException("Failed to open encrypted database")
 ```
+
+### No Network Access
+
+The app declares **no INTERNET permission** in the manifest. This is enforced by a
+Robolectric unit test (`ManifestPermissionTest`) that fails if any manifest merge
+reintroduces it. Never add network calls, analytics SDKs, crash reporters, or any
+dependency that requires `android.permission.INTERNET`.
+
+### Screenshot Protection
+
+`MainActivity` sets `FLAG_SECURE` on the window before `setContent`. This blocks
+screenshots, screen recording, and recent-apps thumbnails. Do not remove this flag
+or add any code path that clears it.
+
+### .gitignore — Credential and Key Exclusions
+
+The `.gitignore` excludes signing keys and credentials to prevent accidental commits:
+
+```
+*.jks
+*.keystore
+*.p12
+*.pem
+*.env
+.env.*
+```
+
+If you add a new secret file type (API keys, service accounts, etc.), add a
+corresponding `.gitignore` pattern **before** committing.
 
 ### Debug-Only Features
 

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -23,10 +23,11 @@
 
 ## Session Scope
 - After unlock, a Koin `sessionScope` is created and injected with the derived key.
-- Key lifetime = session lifetime.
+- The derived key is **actively zeroized** (`fill(0)`) immediately after the database
+  is opened, via `try/finally` in `createDatabaseAndZeroizeKey()`.
 - On logout or app background timeout:
-    - Key is zeroized in memory.
     - All repositories and DAOs in the scope are closed.
+    - The session scope is destroyed.
 
 ---
 
@@ -39,11 +40,27 @@
 
 ## Network
 - App has **no network permissions** in production.
+- `android.permission.INTERNET` is explicitly absent from the manifest.
+- A Robolectric unit test (`ManifestPermissionTest`) enforces this invariant.
 - All functionality operates offline.
+
+---
+
+## Screen Protection
+- `FLAG_SECURE` is set on the activity window at launch.
+- Blocks screenshots, screen recording, and recent-apps thumbnails.
+
+---
+
+## Logging Hygiene
+- Catch blocks log **message only** (`e.message`), never full stack traces.
+- The global crash handler in `MainActivity` is the sole exception (unrecoverable crashes).
+- No `println()` in Gradle build scripts.
+- Passphrase, derived key, and internal structure are never logged.
 
 ---
 
 ## Threat Model
 - Protect against device theft (offline attacker).
-- Mitigate shoulder-surfing via timeout lock.
+- Mitigate shoulder-surfing via timeout lock and `FLAG_SECURE`.
 - Assume compromised device ⇒ compromised data; user informed of risks.


### PR DESCRIPTION
  Remove unused INTERNET permission, zeroize derived encryption key
  after database creation via try/finally, add FLAG_SECURE screenshot
  protection, harden .gitignore against credential leaks, and reduce
  log verbosity to prevent stack trace exposure in production.

  Signed-off-by: Daniel Simmons Smileybob72801@gmail.com