### PR TITLE
feat(shared): add cycle phase calculation logic

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomPeriodRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomPeriodRepository.kt
@@ -35,6 +35,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.datetime.*
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+import com.veleda.cyclewise.domain.CyclePhaseCalculator
+import com.veleda.cyclewise.domain.models.CyclePhase
 import com.veleda.cyclewise.domain.models.DayDetails
 import com.veleda.cyclewise.domain.models.PeriodLog
 import kotlinx.datetime.DateTimeUnit
@@ -335,13 +337,17 @@ class RoomPeriodRepository(
         ) { cycles, allLogs ->
             val detailsMap = mutableMapOf<LocalDate, DayDetails>()
             val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+            val avgCycleLength = CyclePhaseCalculator.averageCycleLength(cycles)
 
             for (cycle in cycles) {
                 val endDate = cycle.endDate ?: today
                 var currentDate = cycle.startDate
 
                 while (currentDate <= endDate) {
-                    detailsMap[currentDate] = DayDetails(isPeriodDay = true)
+                    detailsMap[currentDate] = DayDetails(
+                        isPeriodDay = true,
+                        cyclePhase = CyclePhase.MENSTRUATION
+                    )
                     currentDate = currentDate.plus(1, DateTimeUnit.DAY)
                 }
             }
@@ -349,10 +355,13 @@ class RoomPeriodRepository(
             for (log in allLogs) {
                 val date = log.entry.entryDate
                 val existingInfo = detailsMap[date] ?: DayDetails()
+                val phase = existingInfo.cyclePhase
+                    ?: CyclePhaseCalculator.calculatePhase(date, cycles, avgCycleLength)
                 detailsMap[date] = existingInfo.copy(
                     isPeriodDay = existingInfo.isPeriodDay || log.periodLog != null,
                     hasLoggedSymptoms = log.symptomLogs.isNotEmpty(),
-                    hasLoggedMedications = log.medicationLogs.isNotEmpty()
+                    hasLoggedMedications = log.medicationLogs.isNotEmpty(),
+                    cyclePhase = phase
                 )
             }
             detailsMap

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/CalendarDayInfo.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/CalendarDayInfo.kt
@@ -1,10 +1,18 @@
 package com.veleda.cyclewise.ui.tracker
 
+import com.veleda.cyclewise.domain.models.CyclePhase
+
 /**
  * A simple data holder representing the special status of a day on the calendar.
+ *
+ * @property isPeriodDay   True if this date falls within a saved period's date range.
+ * @property hasSymptoms   True if at least one symptom log exists for this date.
+ * @property hasMedications True if at least one medication log exists for this date.
+ * @property cyclePhase    Computed cycle phase for this date, or null if not determinable.
  */
 data class CalendarDayInfo(
     val isPeriodDay: Boolean = false,
     val hasSymptoms: Boolean = false,
-    val hasMedications: Boolean = false
+    val hasMedications: Boolean = false,
+    val cyclePhase: CyclePhase? = null
 )

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
@@ -67,7 +67,8 @@ class TrackerViewModel(
                         CalendarDayInfo(
                             isPeriodDay = domainDetails.isPeriodDay,
                             hasSymptoms = domainDetails.hasLoggedSymptoms,
-                            hasMedications = domainDetails.hasLoggedMedications
+                            hasMedications = domainDetails.hasLoggedMedications,
+                            cyclePhase = domainDetails.cyclePhase
                         )
                     }
                 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/CyclePhaseCalculatorTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/CyclePhaseCalculatorTest.kt
@@ -1,0 +1,419 @@
+package com.veleda.cyclewise.domain
+
+import com.veleda.cyclewise.domain.models.CyclePhase
+import com.veleda.cyclewise.testutil.TestData
+import com.veleda.cyclewise.testutil.buildPeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.plus
+import kotlinx.datetime.minus
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CyclePhaseCalculatorTest {
+
+    // ==================== calculatePhase tests ====================
+
+    @Test
+    fun calculatePhase_WHEN_noPeriods_THEN_returnsNull() {
+        // ARRANGE
+        val date = TestData.DATE
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(date, emptyList(), 28.0)
+
+        // ASSERT
+        assertNull(result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dateBeforeFirstPeriod_THEN_returnsNull() {
+        // ARRANGE
+        val periodStart = LocalDate(2025, 3, 1)
+        val periods = listOf(buildPeriod(startDate = periodStart, endDate = LocalDate(2025, 3, 5)))
+        val dateBefore = LocalDate(2025, 2, 20)
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(dateBefore, periods, 28.0)
+
+        // ASSERT
+        assertNull(result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dateDuringPeriod_THEN_returnsMenstruation() {
+        // ARRANGE
+        val period1Start = LocalDate(2025, 3, 1)
+        val period1End = LocalDate(2025, 3, 5)
+        val period2Start = LocalDate(2025, 3, 29)
+        val period2End = LocalDate(2025, 4, 2)
+        val periods = listOf(
+            buildPeriod(startDate = period1Start, endDate = period1End),
+            buildPeriod(startDate = period2Start, endDate = period2End)
+        )
+        val dateInPeriod = LocalDate(2025, 3, 3) // Day 3 of first period
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(dateInPeriod, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.MENSTRUATION, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dateOnPeriodStartDay_THEN_returnsMenstruation() {
+        // ARRANGE
+        val periodStart = LocalDate(2025, 3, 1)
+        val periods = listOf(
+            buildPeriod(startDate = periodStart, endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2))
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(periodStart, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.MENSTRUATION, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dateOnPeriodEndDay_THEN_returnsMenstruation() {
+        // ARRANGE
+        val periodEnd = LocalDate(2025, 3, 5)
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = periodEnd),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2))
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(periodEnd, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.MENSTRUATION, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dateInFollicularPhase_THEN_returnsFollicular() {
+        // ARRANGE — 28-day cycle: period Mar 1-5, next period Mar 29
+        // Luteal starts day 15 (Mar 15), ovulation days 12-14 (Mar 12-14)
+        // Follicular: days 6-11 (Mar 6-11)
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2))
+        )
+        val follicularDate = LocalDate(2025, 3, 8) // Day 8 of cycle
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(follicularDate, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.FOLLICULAR, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dateInOvulationWindow_THEN_returnsOvulation() {
+        // ARRANGE — 28-day cycle: period Mar 1-5, next period Mar 29
+        // Cycle length = 28, luteal starts at day 15, ovulation = days 12-14
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2))
+        )
+        val ovulationDate = LocalDate(2025, 3, 13) // Day 13 of 28-day cycle
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(ovulationDate, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.OVULATION, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dateInLutealPhase_THEN_returnsLuteal() {
+        // ARRANGE — 28-day cycle: period Mar 1-5, next period Mar 29
+        // Luteal phase: days 15-28 (Mar 15-28)
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2))
+        )
+        val lutealDate = LocalDate(2025, 3, 20) // Day 20 of 28-day cycle
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(lutealDate, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.LUTEAL, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_standard28DayCycle_THEN_allPhasesAtExpectedBoundaries() {
+        // ARRANGE — Classic 28-day cycle: period days 1-5
+        // Follicular: days 6-11, Ovulation: days 12-14, Luteal: days 15-28
+        val cycleStart = LocalDate(2025, 3, 1)
+        val cycleEnd = LocalDate(2025, 3, 5)
+        val nextCycleStart = LocalDate(2025, 3, 29) // 28 days later
+        val periods = listOf(
+            buildPeriod(startDate = cycleStart, endDate = cycleEnd),
+            buildPeriod(startDate = nextCycleStart, endDate = LocalDate(2025, 4, 2))
+        )
+
+        // ACT & ASSERT — Check each phase boundary
+        // Day 1 (Mar 1) = MENSTRUATION
+        assertEquals(CyclePhase.MENSTRUATION, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 1), periods, 28.0))
+        // Day 5 (Mar 5) = MENSTRUATION (last period day)
+        assertEquals(CyclePhase.MENSTRUATION, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 5), periods, 28.0))
+        // Day 6 (Mar 6) = FOLLICULAR (first post-period day)
+        assertEquals(CyclePhase.FOLLICULAR, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 6), periods, 28.0))
+        // Day 11 (Mar 11) = FOLLICULAR (last follicular day)
+        assertEquals(CyclePhase.FOLLICULAR, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 11), periods, 28.0))
+        // Day 12 (Mar 12) = OVULATION (first ovulation day)
+        assertEquals(CyclePhase.OVULATION, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 12), periods, 28.0))
+        // Day 14 (Mar 14) = OVULATION (last ovulation day)
+        assertEquals(CyclePhase.OVULATION, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 14), periods, 28.0))
+        // Day 15 (Mar 15) = LUTEAL (first luteal day)
+        assertEquals(CyclePhase.LUTEAL, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 15), periods, 28.0))
+        // Day 28 (Mar 28) = LUTEAL (last day of cycle)
+        assertEquals(CyclePhase.LUTEAL, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 28), periods, 28.0))
+    }
+
+    @Test
+    fun calculatePhase_WHEN_ongoingCycleWithAverage_THEN_returnsCorrectPhase() {
+        // ARRANGE — One ongoing period (no end date implied through completed periods for avg),
+        // plus a completed period to establish an average
+        // We need at least 2 completed periods for averageCycleLength, but calculatePhase
+        // accepts average as a parameter directly
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5))
+        )
+        // Date in the follicular phase of the latest cycle, using avg of 28
+        val follicularDate = LocalDate(2025, 3, 8) // Day 8
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(follicularDate, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.FOLLICULAR, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_ongoingCycleWithAverage_THEN_lutealPredicted() {
+        // ARRANGE — Single completed period, date falls in predicted luteal zone
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5))
+        )
+        val lutealDate = LocalDate(2025, 3, 20) // Day 20 of predicted 28-day cycle
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(lutealDate, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.LUTEAL, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_nullAverageAndPastLastPeriod_THEN_returnsNull() {
+        // ARRANGE — Single completed period, no average available, date after period ends
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5))
+        )
+        val dateAfter = LocalDate(2025, 3, 10)
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(dateAfter, periods, null)
+
+        // ASSERT
+        assertNull(result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_shortCycle21Days_THEN_phasesStillValid() {
+        // ARRANGE — 21-day cycle: period Mar 1-4, next period Mar 22
+        // Luteal starts day 8 (21-14+1), ovulation days 5-7, follicular has no room
+        // (period ends day 4, ovulation starts day 5)
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 4)),
+            buildPeriod(startDate = LocalDate(2025, 3, 22), endDate = LocalDate(2025, 3, 25))
+        )
+
+        // Day 4 (Mar 4) = MENSTRUATION
+        assertEquals(CyclePhase.MENSTRUATION, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 4), periods, null))
+        // Day 5 (Mar 5) = OVULATION (ovulation window starts immediately after period)
+        assertEquals(CyclePhase.OVULATION, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 5), periods, null))
+        // Day 7 (Mar 7) = OVULATION
+        assertEquals(CyclePhase.OVULATION, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 7), periods, null))
+        // Day 8 (Mar 8) = LUTEAL
+        assertEquals(CyclePhase.LUTEAL, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 8), periods, null))
+        // Day 21 (Mar 21) = LUTEAL
+        assertEquals(CyclePhase.LUTEAL, CyclePhaseCalculator.calculatePhase(LocalDate(2025, 3, 21), periods, null))
+    }
+
+    @Test
+    fun calculatePhase_WHEN_datePastExpectedCycleEnd_THEN_returnsNull() {
+        // ARRANGE — Single completed period, avg = 28, date is day 30
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5))
+        )
+        val dateWayAfter = LocalDate(2025, 3, 31) // Day 31, past the 28-day cycle
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(dateWayAfter, periods, 28.0)
+
+        // ASSERT
+        assertNull(result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_ongoingPeriodNoEndDate_THEN_returnsMenstruation() {
+        // ARRANGE — Single ongoing period with no end date
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = null)
+        )
+        val dateInOngoing = LocalDate(2025, 3, 3)
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(dateInOngoing, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.MENSTRUATION, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_periodsAreUnsorted_THEN_sortsInternallyAndReturnsCorrectPhase() {
+        // ARRANGE — Periods given in reverse order
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2)),
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5))
+        )
+        val follicularDate = LocalDate(2025, 3, 8) // Day 8 of first cycle
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(follicularDate, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.FOLLICULAR, result)
+    }
+
+    @Test
+    fun calculatePhase_WHEN_dayAfterPeriodEnds_THEN_returnsFollicular() {
+        // ARRANGE
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2))
+        )
+        val dayAfterPeriod = LocalDate(2025, 3, 6) // Day 6, first post-period day
+
+        // ACT
+        val result = CyclePhaseCalculator.calculatePhase(dayAfterPeriod, periods, 28.0)
+
+        // ASSERT
+        assertEquals(CyclePhase.FOLLICULAR, result)
+    }
+
+    // ==================== averageCycleLength tests ====================
+
+    @Test
+    fun averageCycleLength_WHEN_multipleCompletedPeriods_THEN_returnsCorrectAverage() {
+        // ARRANGE — 3 completed periods with known start dates
+        // Cycle 1: Mar 1 -> Mar 29 = 28 days
+        // Cycle 2: Mar 29 -> Apr 28 = 30 days
+        // Average = (28 + 30) / 2 = 29.0
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2)),
+            buildPeriod(startDate = LocalDate(2025, 4, 28), endDate = LocalDate(2025, 5, 2))
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.averageCycleLength(periods)
+
+        // ASSERT
+        assertEquals(29.0, result)
+    }
+
+    @Test
+    fun averageCycleLength_WHEN_singlePeriod_THEN_returnsNull() {
+        // ARRANGE
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5))
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.averageCycleLength(periods)
+
+        // ASSERT
+        assertNull(result)
+    }
+
+    @Test
+    fun averageCycleLength_WHEN_noPeriods_THEN_returnsNull() {
+        // ACT
+        val result = CyclePhaseCalculator.averageCycleLength(emptyList())
+
+        // ASSERT
+        assertNull(result)
+    }
+
+    @Test
+    fun averageCycleLength_WHEN_ongoingPeriodExcluded_THEN_usesOnlyCompleted() {
+        // ARRANGE — 2 completed + 1 ongoing; only completed should be used
+        // Cycle 1: Mar 1 -> Mar 29 = 28 days
+        // Ongoing period (endDate = null) should be excluded
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2)),
+            buildPeriod(startDate = LocalDate(2025, 4, 26), endDate = null)
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.averageCycleLength(periods)
+
+        // ASSERT — Only 2 completed periods, cycle length = 28
+        assertEquals(28.0, result)
+    }
+
+    @Test
+    fun averageCycleLength_WHEN_allOngoing_THEN_returnsNull() {
+        // ARRANGE — Only ongoing periods (no end dates)
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = null),
+            buildPeriod(startDate = LocalDate(2025, 4, 1), endDate = null)
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.averageCycleLength(periods)
+
+        // ASSERT
+        assertNull(result)
+    }
+
+    @Test
+    fun averageCycleLength_WHEN_periodsUnsorted_THEN_sortsInternallyAndReturnsCorrectAverage() {
+        // ARRANGE — Periods given in reverse order
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 4, 28), endDate = LocalDate(2025, 5, 2)),
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 29), endDate = LocalDate(2025, 4, 2))
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.averageCycleLength(periods)
+
+        // ASSERT — (28 + 30) / 2 = 29.0
+        assertEquals(29.0, result)
+    }
+
+    @Test
+    fun averageCycleLength_WHEN_exactlyTwoCompletedPeriods_THEN_returnsDistance() {
+        // ARRANGE
+        val periods = listOf(
+            buildPeriod(startDate = LocalDate(2025, 3, 1), endDate = LocalDate(2025, 3, 5)),
+            buildPeriod(startDate = LocalDate(2025, 3, 27), endDate = LocalDate(2025, 3, 30))
+        )
+
+        // ACT
+        val result = CyclePhaseCalculator.averageCycleLength(periods)
+
+        // ASSERT — 26 days between Mar 1 and Mar 27
+        assertEquals(26.0, result)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/CyclePhaseCalculator.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/CyclePhaseCalculator.kt
@@ -1,0 +1,133 @@
+package com.veleda.cyclewise.domain
+
+import com.veleda.cyclewise.domain.models.CyclePhase
+import com.veleda.cyclewise.domain.models.Period
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.daysUntil
+
+/**
+ * Stateless calculator that determines the [CyclePhase] for any given date
+ * based on period history and average cycle length.
+ *
+ * Phase boundaries follow a standard ovulatory model where the luteal phase
+ * is fixed at 14 days and the ovulation window spans 3 days before that.
+ *
+ * All functions are pure — no side effects, no state, no I/O.
+ */
+object CyclePhaseCalculator {
+
+    /** Fixed luteal phase length in days (standard ovulatory model). */
+    private const val LUTEAL_PHASE_LENGTH = 14
+
+    /** Number of days in the ovulation window preceding the luteal phase. */
+    private const val OVULATION_WINDOW_LENGTH = 3
+
+    /**
+     * Determines the cycle phase for [date] given the user's [periods] and [averageCycleLength].
+     *
+     * Algorithm:
+     * 1. Sort periods chronologically by start date.
+     * 2. Find the **owning period** — the period whose start date is on or before [date]
+     *    and whose next period's start date is after [date] (or it is the most recent period).
+     * 3. If [date] falls within the owning period's start..end range, return [CyclePhase.MENSTRUATION].
+     * 4. Determine expected cycle length: actual (start-to-start) for past cycles,
+     *    or [averageCycleLength] for the current/latest cycle.
+     * 5. Compute phase boundaries forward from the owning period's start date.
+     *
+     * @param date               the date to classify.
+     * @param periods            all recorded periods (any sort order accepted).
+     * @param averageCycleLength average cycle length in days, or null if insufficient data.
+     * @return the computed [CyclePhase], or null if the date cannot be classified.
+     */
+    fun calculatePhase(
+        date: LocalDate,
+        periods: List<Period>,
+        averageCycleLength: Double?
+    ): CyclePhase? {
+        if (periods.isEmpty()) return null
+
+        val sorted = periods.sortedBy { it.startDate }
+
+        // Date is before any recorded period
+        if (date < sorted.first().startDate) return null
+
+        // Find the owning period: last period whose startDate <= date
+        val owningIndex = sorted.indexOfLast { it.startDate <= date }
+        if (owningIndex == -1) return null
+
+        val owningPeriod = sorted[owningIndex]
+        val nextPeriod = sorted.getOrNull(owningIndex + 1)
+
+        // If there's a next period and date is on or after its start, the date
+        // belongs to that cycle instead — recurse is unnecessary since we used indexOfLast
+        if (nextPeriod != null && date >= nextPeriod.startDate) return null
+
+        // Check if date is within the menstruation range
+        val periodEnd = owningPeriod.endDate
+        if (periodEnd != null && date in owningPeriod.startDate..periodEnd) {
+            return CyclePhase.MENSTRUATION
+        }
+        // Ongoing period with no end date: all days from start onward are menstruation
+        if (periodEnd == null && date >= owningPeriod.startDate && nextPeriod == null) {
+            // For ongoing periods, if we have no end date, days from start are menstruation
+            // unless we have an average and can predict the end
+            return CyclePhase.MENSTRUATION
+        }
+
+        // Determine cycle length for phase computation
+        val cycleLength: Int = if (nextPeriod != null) {
+            // Past cycle: actual start-to-start distance
+            owningPeriod.startDate.daysUntil(nextPeriod.startDate)
+        } else {
+            // Current/latest cycle: use average
+            averageCycleLength?.toInt() ?: return null
+        }
+
+        // Guard: cycle too short for meaningful phase computation
+        if (cycleLength < 1) return null
+
+        val dayInCycle = owningPeriod.startDate.daysUntil(date) + 1 // 1-based
+
+        // Menstruation end day (1-based) — use actual period end if available
+        val menstruationEndDay = if (periodEnd != null) {
+            owningPeriod.startDate.daysUntil(periodEnd) + 1
+        } else {
+            // Shouldn't reach here for ongoing with no next period (handled above),
+            // but for safety:
+            1
+        }
+
+        // Luteal starts at cycleLength - LUTEAL_PHASE_LENGTH + 1 (1-based)
+        val lutealStartDay = cycleLength - LUTEAL_PHASE_LENGTH + 1
+
+        // Ovulation window: 3 days before luteal start
+        val ovulationStartDay = lutealStartDay - OVULATION_WINDOW_LENGTH
+        val ovulationEndDay = lutealStartDay - 1
+
+        return when {
+            dayInCycle <= menstruationEndDay -> CyclePhase.MENSTRUATION
+            dayInCycle > cycleLength -> null // Past expected cycle end
+            dayInCycle >= lutealStartDay -> CyclePhase.LUTEAL
+            dayInCycle in ovulationStartDay..ovulationEndDay -> CyclePhase.OVULATION
+            dayInCycle > menstruationEndDay -> CyclePhase.FOLLICULAR
+            else -> null
+        }
+    }
+
+    /**
+     * Computes the average cycle length (start-to-start) from completed periods.
+     *
+     * Only periods with a non-null [Period.endDate] are considered. At least 2 completed
+     * periods are required to compute a meaningful average.
+     *
+     * @param periods all recorded periods (any sort order accepted).
+     * @return the average cycle length in days, or null if fewer than 2 completed periods exist.
+     */
+    fun averageCycleLength(periods: List<Period>): Double? {
+        val completed = periods.filter { it.endDate != null }.sortedBy { it.startDate }
+        if (completed.size < 2) return null
+        return completed.zipWithNext { current, next ->
+            current.startDate.daysUntil(next.startDate).toDouble()
+        }.average()
+    }
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/CyclePhase.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/CyclePhase.kt
@@ -1,0 +1,27 @@
+package com.veleda.cyclewise.domain.models
+
+/**
+ * Computed classification of a day within a menstrual cycle.
+ *
+ * Unlike user-entered attributes (e.g. [FlowIntensity]), cycle phase is derived
+ * algorithmically from period history and average cycle length by
+ * [com.veleda.cyclewise.domain.CyclePhaseCalculator].
+ *
+ * Phase boundaries follow a standard ovulatory model:
+ * - **Luteal phase** is fixed at the last 14 days of a cycle.
+ * - **Ovulation window** is the 3 days immediately before the luteal phase.
+ * - **Follicular phase** fills the gap between menstruation end and ovulation start.
+ */
+enum class CyclePhase {
+    /** Active menstrual bleeding days (period start through period end). */
+    MENSTRUATION,
+
+    /** Post-menstruation phase where follicles develop; ends before the ovulation window. */
+    FOLLICULAR,
+
+    /** Three-day window around estimated ovulation, immediately before the luteal phase. */
+    OVULATION,
+
+    /** Post-ovulation phase; fixed at the last 14 days of the cycle. */
+    LUTEAL
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/DayDetails.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/DayDetails.kt
@@ -7,12 +7,14 @@ package com.veleda.cyclewise.domain.models
  * for the calendar UI. Each flag indicates whether the corresponding data type
  * has been recorded for this day.
  *
- * @property isPeriodDay         True if this date falls within any saved period's date range.
- * @property hasLoggedSymptoms   True if at least one [SymptomLog] exists for this date.
+ * @property isPeriodDay          True if this date falls within any saved period's date range.
+ * @property hasLoggedSymptoms    True if at least one [SymptomLog] exists for this date.
  * @property hasLoggedMedications True if at least one [MedicationLog] exists for this date.
+ * @property cyclePhase           Computed cycle phase for this date, or null if not determinable.
  */
 data class DayDetails(
     val isPeriodDay: Boolean = false,
     val hasLoggedSymptoms: Boolean = false,
-    val hasLoggedMedications: Boolean = false
+    val hasLoggedMedications: Boolean = false,
+    val cyclePhase: CyclePhase? = null
 )


### PR DESCRIPTION
  Introduce CyclePhase enum and CyclePhaseCalculator to classify any calendar date into one of four menstrual cycle phases (Menstruation, Follicular, Ovulation, Luteal) based on period history and average cycle length.

  - Add CyclePhase enum with KDoc for each phase
  - Create stateless CyclePhaseCalculator object with calculatePhase() and averageCycleLength() pure functions
  - Add cyclePhase field to DayDetails and CalendarDayInfo data classes
  - Wire phase computation into RoomPeriodRepository.observeDayDetails()
  - Propagate cyclePhase through TrackerViewModel mapping
  - Add comprehensive unit tests for calculator and average computation

  Signed-off-by: Daniel Simmons SmileyBob72801@gmail.com