### PR TITLE
feat(reminders): add local WorkManager-based notification reminders

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
             implementation(libs.androidx.datastore.preferences)
             implementation(libs.compose.calendar)
             implementation(libs.uuid)
+            implementation(libs.workmanager.runtime)
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -77,6 +78,7 @@ kotlin {
                 implementation(libs.androidx.test.core)
                 implementation(libs.koin.test)
                 implementation(libs.koin.test.junit4)
+                implementation(libs.workmanager.testing)
             }
         }
     }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name="com.veleda.cyclewise.CycleWiseApp"
         android:allowBackup="false"

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/CycleWiseApp.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/CycleWiseApp.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.veleda.cyclewise.di.appModule
+import com.veleda.cyclewise.reminders.ReminderNotifier
 import com.veleda.cyclewise.settings.AppSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -46,6 +47,8 @@ class CycleWiseApp :
             modules(appModule)
             allowOverride(false)
         }
+
+        ReminderNotifier.ensureChannel(this)
 
         prefs = getSharedPreferences("autolock_prefs", MODE_PRIVATE)
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
@@ -30,6 +30,7 @@ import com.veleda.cyclewise.session.SessionBus
 import com.veleda.cyclewise.ui.log.DailyLogViewModel
 import com.veleda.cyclewise.settings.AppSettings
 import com.veleda.cyclewise.ui.auth.PassphraseViewModel
+import com.veleda.cyclewise.reminders.ReminderScheduler
 import com.veleda.cyclewise.ui.insights.InsightsViewModel
 import kotlinx.datetime.LocalDate
 import org.koin.core.qualifier.Qualifier
@@ -73,7 +74,7 @@ internal fun createDatabaseAndZeroizeKey(
  *
  * **Singleton scope** (lives for the app process):
  * [SaltStorage], [AppSettings], [SessionBus], [PassphraseService], [LockedWaterDraft],
- * [InsightEngine], [WaterTrackerViewModel], [PassphraseViewModel].
+ * [ReminderScheduler], [InsightEngine], [WaterTrackerViewModel], [PassphraseViewModel].
  *
  * **Session scope** ([SESSION_SCOPE], created on unlock, destroyed on logout/autolock):
  * [PeriodDatabase], all DAOs, [PeriodRepository], use cases, library providers,
@@ -102,6 +103,8 @@ val appModule = module {
     }
 
     single { LockedWaterDraft(androidContext()) }
+
+    single { ReminderScheduler(androidContext()) }
 
     viewModel { WaterTrackerViewModel(lockedWaterDraft = get()) }
 
@@ -153,7 +156,8 @@ val appModule = module {
                 periodRepository = get(),
                 symptomLibraryProvider = get(),
                 medicationLibraryProvider = get(),
-                autoClosePeriodUseCase = get()
+                autoClosePeriodUseCase = get(),
+                appSettings = get()
             )
         }
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/ReminderNotifier.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/ReminderNotifier.kt
@@ -1,0 +1,111 @@
+package com.veleda.cyclewise.reminders
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.veleda.cyclewise.MainActivity
+import com.veleda.cyclewise.R
+
+/**
+ * Singleton responsible for creating the notification channel and posting
+ * privacy-safe reminder notifications.
+ *
+ * All notification content is **static** — title and body are string resources
+ * containing no health data. This is enforced here so individual workers cannot
+ * accidentally leak sensitive information.
+ */
+object ReminderNotifier {
+
+    private const val CHANNEL_ID = "reminders"
+    private const val CHANNEL_NAME = "Reminders"
+
+    /** Notification ID for the period prediction reminder. */
+    const val NOTIFICATION_ID_PERIOD = 1001
+
+    /** Notification ID for the daily medication reminder. */
+    const val NOTIFICATION_ID_MEDICATION = 1002
+
+    /** Notification ID for the hydration reminder. */
+    const val NOTIFICATION_ID_HYDRATION = 1003
+
+    /**
+     * Creates the `"reminders"` notification channel.
+     *
+     * Safe to call multiple times — [NotificationManager.createNotificationChannel]
+     * is idempotent. Must be called before any worker attempts to post a notification.
+     *
+     * @param context application context.
+     */
+    fun ensureChannel(context: Context) {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        val manager = context.getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(channel)
+    }
+
+    /**
+     * Posts a notification with static, privacy-safe content.
+     *
+     * Title and body come from string resources (`reminder_notification_title` /
+     * `reminder_notification_body`). Tapping the notification opens [MainActivity].
+     * Silently no-ops if the POST_NOTIFICATIONS permission is not granted.
+     *
+     * @param context        application context.
+     * @param notificationId one of [NOTIFICATION_ID_PERIOD], [NOTIFICATION_ID_MEDICATION],
+     *                       or [NOTIFICATION_ID_HYDRATION].
+     */
+    fun notify(context: Context, notificationId: Int) {
+        if (!hasPermission(context)) return
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            notificationId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(context.getString(R.string.reminder_notification_title))
+            .setContentText(context.getString(R.string.reminder_notification_body))
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(notificationId, notification)
+    }
+
+    /**
+     * Returns `true` if the app has permission to post notifications.
+     *
+     * On API < 33 (pre-Tiramisu), POST_NOTIFICATIONS is not required, so this
+     * always returns `true`. On API 33+, checks the runtime permission.
+     *
+     * @param context application context.
+     */
+    fun hasPermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/ReminderScheduler.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/ReminderScheduler.kt
@@ -1,0 +1,142 @@
+package com.veleda.cyclewise.reminders
+
+import android.content.Context
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import com.veleda.cyclewise.reminders.workers.HydrationReminderWorker
+import com.veleda.cyclewise.reminders.workers.MedicationReminderWorker
+import com.veleda.cyclewise.reminders.workers.PeriodPredictionWorker
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+
+/**
+ * Coordinator that enqueues and cancels WorkManager periodic jobs for all
+ * three reminder types.
+ *
+ * Registered as a Koin singleton. Uses [ExistingPeriodicWorkPolicy.UPDATE]
+ * so parameter changes (e.g. new medication time) replace the existing work
+ * without cancelling first.
+ *
+ * @param context application context used to obtain the [WorkManager] instance.
+ */
+class ReminderScheduler(private val context: Context) {
+
+    companion object {
+        /** Unique work name for the period prediction reminder. */
+        const val WORK_NAME_PERIOD = "reminder_period_prediction"
+
+        /** Unique work name for the daily medication reminder. */
+        const val WORK_NAME_MEDICATION = "reminder_medication_daily"
+
+        /** Unique work name for the hydration reminder. */
+        const val WORK_NAME_HYDRATION = "reminder_hydration"
+    }
+
+    private val workManager get() = WorkManager.getInstance(context)
+
+    /**
+     * Schedules or cancels the daily period prediction check.
+     *
+     * When enabled, enqueues a ~24h periodic worker with 1h flex that reads
+     * the cached predicted date from DataStore and notifies if within window.
+     *
+     * @param enabled `true` to schedule, `false` to cancel.
+     */
+    fun schedulePeriodPrediction(enabled: Boolean) {
+        if (!enabled) {
+            workManager.cancelUniqueWork(WORK_NAME_PERIOD)
+            return
+        }
+        val request = PeriodicWorkRequestBuilder<PeriodPredictionWorker>(
+            24, TimeUnit.HOURS,
+            1, TimeUnit.HOURS
+        ).build()
+        workManager.enqueueUniquePeriodicWork(
+            WORK_NAME_PERIOD,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+
+    /**
+     * Schedules or cancels the daily medication reminder.
+     *
+     * When enabled, computes an initial delay so the first execution targets
+     * the user's chosen time, then repeats every ~24h with 30min flex.
+     *
+     * @param enabled `true` to schedule, `false` to cancel.
+     * @param hour    target hour of day (0–23).
+     * @param minute  target minute of hour (0–59).
+     */
+    fun scheduleMedication(enabled: Boolean, hour: Int = 9, minute: Int = 0) {
+        if (!enabled) {
+            workManager.cancelUniqueWork(WORK_NAME_MEDICATION)
+            return
+        }
+        val initialDelay = computeInitialDelay(hour, minute)
+        val request = PeriodicWorkRequestBuilder<MedicationReminderWorker>(
+            24, TimeUnit.HOURS,
+            30, TimeUnit.MINUTES
+        ).setInitialDelay(initialDelay, TimeUnit.MILLISECONDS)
+            .build()
+        workManager.enqueueUniquePeriodicWork(
+            WORK_NAME_MEDICATION,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+
+    /**
+     * Schedules or cancels the periodic hydration reminder.
+     *
+     * When enabled, uses the user's chosen frequency (2/3/4 hours) as the
+     * repeat interval with 15min flex.
+     *
+     * @param enabled        `true` to schedule, `false` to cancel.
+     * @param frequencyHours interval between reminders (2, 3, or 4).
+     */
+    fun scheduleHydration(enabled: Boolean, frequencyHours: Int = 3) {
+        if (!enabled) {
+            workManager.cancelUniqueWork(WORK_NAME_HYDRATION)
+            return
+        }
+        val request = PeriodicWorkRequestBuilder<HydrationReminderWorker>(
+            frequencyHours.toLong(), TimeUnit.HOURS,
+            15, TimeUnit.MINUTES
+        ).build()
+        workManager.enqueueUniquePeriodicWork(
+            WORK_NAME_HYDRATION,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+
+    /**
+     * Cancels all three reminder work requests.
+     */
+    fun cancelAll() {
+        workManager.cancelUniqueWork(WORK_NAME_PERIOD)
+        workManager.cancelUniqueWork(WORK_NAME_MEDICATION)
+        workManager.cancelUniqueWork(WORK_NAME_HYDRATION)
+    }
+
+    /**
+     * Computes the delay in milliseconds from now until the next occurrence of
+     * the given [hour]:[minute]. If the target time has already passed today,
+     * returns the delay until that time tomorrow.
+     */
+    private fun computeInitialDelay(hour: Int, minute: Int): Long {
+        val now = Calendar.getInstance()
+        val target = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        if (target.before(now)) {
+            target.add(Calendar.DAY_OF_MONTH, 1)
+        }
+        return target.timeInMillis - now.timeInMillis
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/workers/HydrationReminderWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/workers/HydrationReminderWorker.kt
@@ -1,0 +1,57 @@
+package com.veleda.cyclewise.reminders.workers
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.veleda.cyclewise.androidData.local.draft.LockedWaterDraft
+import com.veleda.cyclewise.reminders.ReminderNotifier
+import com.veleda.cyclewise.settings.AppSettings
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import kotlin.time.Clock
+
+/**
+ * Periodic background worker that reminds the user to log water intake.
+ *
+ * Reads the active window (start/end hour), daily goal, and today's draft
+ * water cups from [AppSettings] and [LockedWaterDraft] (both plaintext
+ * DataStore). Skips notification if:
+ * - The current hour is outside the `[startHour, endHour)` active window.
+ * - Today's logged cups already meet or exceed the goal.
+ *
+ * The worker never accesses the encrypted database.
+ *
+ * Scheduled at the user's chosen frequency (2/3/4h periodic, 15min flex)
+ * by [ReminderScheduler][com.veleda.cyclewise.reminders.ReminderScheduler].
+ */
+class HydrationReminderWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val appSettings = AppSettings(applicationContext)
+        val lockedWaterDraft = LockedWaterDraft(applicationContext)
+
+        val startHour = appSettings.reminderHydrationStartHour.first()
+        val endHour = appSettings.reminderHydrationEndHour.first()
+        val goalCups = appSettings.reminderHydrationGoalCups.first()
+
+        val currentHour = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
+        if (currentHour < startHour || currentHour >= endHour) {
+            return Result.success()
+        }
+
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+        val drafts = lockedWaterDraft.drafts.first()
+        val todayCups = drafts[today] ?: 0
+
+        if (todayCups >= goalCups) {
+            return Result.success()
+        }
+
+        ReminderNotifier.notify(applicationContext, ReminderNotifier.NOTIFICATION_ID_HYDRATION)
+        return Result.success()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/workers/MedicationReminderWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/workers/MedicationReminderWorker.kt
@@ -1,0 +1,26 @@
+package com.veleda.cyclewise.reminders.workers
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.veleda.cyclewise.reminders.ReminderNotifier
+
+/**
+ * Daily background worker that posts a generic medication reminder notification.
+ *
+ * Scheduling (including time-of-day targeting via initial delay) is handled by
+ * [ReminderScheduler][com.veleda.cyclewise.reminders.ReminderScheduler]. The worker
+ * itself simply fires the notification on every execution.
+ *
+ * Scheduled as ~24h periodic work with 30min flex.
+ */
+class MedicationReminderWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        ReminderNotifier.notify(applicationContext, ReminderNotifier.NOTIFICATION_ID_MEDICATION)
+        return Result.success()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/workers/PeriodPredictionWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/reminders/workers/PeriodPredictionWorker.kt
@@ -1,0 +1,49 @@
+package com.veleda.cyclewise.reminders.workers
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.veleda.cyclewise.reminders.ReminderNotifier
+import com.veleda.cyclewise.settings.AppSettings
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.todayIn
+import kotlin.time.Clock
+
+/**
+ * Daily background worker that checks whether the predicted next period date
+ * falls within the user's configured notification window.
+ *
+ * Reads the cached predicted date and "days before" setting from [AppSettings]
+ * (plaintext DataStore). If the prediction is blank, unparseable, or outside
+ * the window, the worker completes silently. The worker never accesses the
+ * encrypted database.
+ *
+ * Scheduled as ~24h periodic work with 1h flex by [ReminderScheduler][com.veleda.cyclewise.reminders.ReminderScheduler].
+ */
+class PeriodPredictionWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        val appSettings = AppSettings(applicationContext)
+        val cachedDate = appSettings.cachedPredictedPeriodDate.first()
+        if (cachedDate.isBlank()) return Result.success()
+
+        val predictedDate = runCatching { LocalDate.parse(cachedDate) }.getOrNull()
+            ?: return Result.success()
+
+        val daysBefore = appSettings.reminderPeriodDaysBefore.first()
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+        val daysUntil = today.daysUntil(predictedDate)
+
+        if (daysUntil in 0..daysBefore) {
+            ReminderNotifier.notify(applicationContext, ReminderNotifier.NOTIFICATION_ID_PERIOD)
+        }
+
+        return Result.success()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
@@ -23,6 +23,20 @@ private val FOLLICULAR_COLOR = stringPreferencesKey("follicular_color")
 private val OVULATION_COLOR = stringPreferencesKey("ovulation_color")
 private val LUTEAL_COLOR = stringPreferencesKey("luteal_color")
 
+// --- Reminder preferences ---
+private val REMINDER_PERIOD_ENABLED = booleanPreferencesKey("reminder_period_enabled")
+private val REMINDER_PERIOD_DAYS_BEFORE = intPreferencesKey("reminder_period_days_before")
+private val REMINDER_PERIOD_PRIVACY_ACCEPTED = booleanPreferencesKey("reminder_period_privacy_accepted")
+private val REMINDER_MEDICATION_ENABLED = booleanPreferencesKey("reminder_medication_enabled")
+private val REMINDER_MEDICATION_HOUR = intPreferencesKey("reminder_medication_hour")
+private val REMINDER_MEDICATION_MINUTE = intPreferencesKey("reminder_medication_minute")
+private val REMINDER_HYDRATION_ENABLED = booleanPreferencesKey("reminder_hydration_enabled")
+private val REMINDER_HYDRATION_GOAL_CUPS = intPreferencesKey("reminder_hydration_goal_cups")
+private val REMINDER_HYDRATION_FREQUENCY_HOURS = intPreferencesKey("reminder_hydration_frequency_hours")
+private val REMINDER_HYDRATION_START_HOUR = intPreferencesKey("reminder_hydration_start_hour")
+private val REMINDER_HYDRATION_END_HOUR = intPreferencesKey("reminder_hydration_end_hour")
+private val CACHED_PREDICTED_PERIOD_DATE = stringPreferencesKey("cached_predicted_period_date")
+
 /**
  * DataStore-backed wrapper for user-configurable app preferences.
  *
@@ -42,6 +56,18 @@ private val LUTEAL_COLOR = stringPreferencesKey("luteal_color")
  * @property follicularColor       Custom hex color for Follicular phase (6-char, no '#'; default: "80CBC4").
  * @property ovulationColor        Custom hex color for Ovulation phase (6-char, no '#'; default: "FFCC80").
  * @property lutealColor           Custom hex color for Luteal phase (6-char, no '#'; default: "B39DDB").
+ * @property reminderPeriodEnabled          Whether the period prediction reminder is enabled (default: false).
+ * @property reminderPeriodDaysBefore       Days before predicted period to notify (1–3, default: 2).
+ * @property reminderPeriodPrivacyAccepted  Whether the user acknowledged the privacy notice for period reminders (default: false).
+ * @property reminderMedicationEnabled      Whether the daily medication reminder is enabled (default: false).
+ * @property reminderMedicationHour         Hour of day for medication reminder (0–23, default: 9).
+ * @property reminderMedicationMinute       Minute of hour for medication reminder (0–59, default: 0).
+ * @property reminderHydrationEnabled       Whether the hydration reminder is enabled (default: false).
+ * @property reminderHydrationGoalCups      Daily water goal in cups (default: 8).
+ * @property reminderHydrationFrequencyHours Interval between hydration reminders in hours (2/3/4, default: 3).
+ * @property reminderHydrationStartHour     Active window start hour (0–23, default: 8).
+ * @property reminderHydrationEndHour       Active window end hour (0–23, default: 20).
+ * @property cachedPredictedPeriodDate      ISO date cache for the period prediction worker (e.g. "2026-03-15").
  */
 class AppSettings(private val context: Context) {
     val autolockMinutes = context.dataStore.data.map { prefs -> prefs[AUTOLOCK_MIN] ?: 10 }
@@ -157,5 +183,115 @@ class AppSettings(private val context: Context) {
     /** Persists the user's custom hex color for the Luteal phase. */
     suspend fun setLutealColor(hex: String) {
         context.dataStore.edit { it[LUTEAL_COLOR] = hex }
+    }
+
+    // ── Reminder preferences ──────────────────────────────────────────
+
+    /** Whether the period prediction reminder is enabled. */
+    val reminderPeriodEnabled: Flow<Boolean> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_PERIOD_ENABLED] ?: false }
+
+    /** Persists the user's preference for the period prediction reminder toggle. */
+    suspend fun setReminderPeriodEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[REMINDER_PERIOD_ENABLED] = enabled }
+    }
+
+    /** Days before the predicted period to send the notification (1–3). */
+    val reminderPeriodDaysBefore: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_PERIOD_DAYS_BEFORE] ?: 2 }
+
+    /** Persists the number of days before a predicted period to notify. */
+    suspend fun setReminderPeriodDaysBefore(days: Int) {
+        context.dataStore.edit { it[REMINDER_PERIOD_DAYS_BEFORE] = days }
+    }
+
+    /** Whether the user has acknowledged the privacy dialog for period reminders. */
+    val reminderPeriodPrivacyAccepted: Flow<Boolean> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_PERIOD_PRIVACY_ACCEPTED] ?: false }
+
+    /** Persists acknowledgement of the period reminder privacy notice. */
+    suspend fun setReminderPeriodPrivacyAccepted(accepted: Boolean) {
+        context.dataStore.edit { it[REMINDER_PERIOD_PRIVACY_ACCEPTED] = accepted }
+    }
+
+    /** Whether the daily medication reminder is enabled. */
+    val reminderMedicationEnabled: Flow<Boolean> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_MEDICATION_ENABLED] ?: false }
+
+    /** Persists the user's preference for the medication reminder toggle. */
+    suspend fun setReminderMedicationEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[REMINDER_MEDICATION_ENABLED] = enabled }
+    }
+
+    /** Hour of day for the medication reminder (0–23). */
+    val reminderMedicationHour: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_MEDICATION_HOUR] ?: 9 }
+
+    /** Persists the medication reminder hour. */
+    suspend fun setReminderMedicationHour(hour: Int) {
+        context.dataStore.edit { it[REMINDER_MEDICATION_HOUR] = hour }
+    }
+
+    /** Minute of hour for the medication reminder (0–59). */
+    val reminderMedicationMinute: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_MEDICATION_MINUTE] ?: 0 }
+
+    /** Persists the medication reminder minute. */
+    suspend fun setReminderMedicationMinute(minute: Int) {
+        context.dataStore.edit { it[REMINDER_MEDICATION_MINUTE] = minute }
+    }
+
+    /** Whether the hydration reminder is enabled. */
+    val reminderHydrationEnabled: Flow<Boolean> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_HYDRATION_ENABLED] ?: false }
+
+    /** Persists the user's preference for the hydration reminder toggle. */
+    suspend fun setReminderHydrationEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[REMINDER_HYDRATION_ENABLED] = enabled }
+    }
+
+    /** Daily water goal in cups. */
+    val reminderHydrationGoalCups: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_HYDRATION_GOAL_CUPS] ?: 8 }
+
+    /** Persists the daily hydration goal. */
+    suspend fun setReminderHydrationGoalCups(cups: Int) {
+        context.dataStore.edit { it[REMINDER_HYDRATION_GOAL_CUPS] = cups }
+    }
+
+    /** Interval between hydration reminders in hours (2/3/4). */
+    val reminderHydrationFrequencyHours: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_HYDRATION_FREQUENCY_HOURS] ?: 3 }
+
+    /** Persists the hydration reminder frequency. */
+    suspend fun setReminderHydrationFrequencyHours(hours: Int) {
+        context.dataStore.edit { it[REMINDER_HYDRATION_FREQUENCY_HOURS] = hours }
+    }
+
+    /** Active window start hour for hydration reminders (0–23). */
+    val reminderHydrationStartHour: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_HYDRATION_START_HOUR] ?: 8 }
+
+    /** Persists the hydration reminder active window start hour. */
+    suspend fun setReminderHydrationStartHour(hour: Int) {
+        context.dataStore.edit { it[REMINDER_HYDRATION_START_HOUR] = hour }
+    }
+
+    /** Active window end hour for hydration reminders (0–23). */
+    val reminderHydrationEndHour: Flow<Int> = context.dataStore.data
+        .map { prefs -> prefs[REMINDER_HYDRATION_END_HOUR] ?: 20 }
+
+    /** Persists the hydration reminder active window end hour. */
+    suspend fun setReminderHydrationEndHour(hour: Int) {
+        context.dataStore.edit { it[REMINDER_HYDRATION_END_HOUR] = hour }
+    }
+
+    /** ISO date cache for the period prediction worker (e.g. "2026-03-15"). */
+    val cachedPredictedPeriodDate: Flow<String> = context.dataStore.data
+        .map { prefs -> prefs[CACHED_PREDICTED_PERIOD_DATE] ?: "" }
+
+    /** Persists the cached predicted period date for the background worker. */
+    suspend fun setCachedPredictedPeriodDate(date: String) {
+        context.dataStore.edit { it[CACHED_PREDICTED_PERIOD_DATE] = date }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/PeriodPrivacyDialog.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/PeriodPrivacyDialog.kt
@@ -1,0 +1,42 @@
+package com.veleda.cyclewise.ui.settings
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.veleda.cyclewise.R
+
+/**
+ * Privacy warning dialog shown the first time the user enables the period
+ * prediction reminder.
+ *
+ * Informs the user that enabling this reminder stores the predicted period date
+ * in unencrypted local storage and that notifications may appear on the lock screen.
+ * The user must explicitly accept before the reminder is activated.
+ *
+ * @param onAccept called when the user taps "I Understand" — should persist
+ *                 [AppSettings.reminderPeriodPrivacyAccepted] and enable the reminder.
+ * @param onDismiss called when the user taps "Cancel" or dismisses the dialog.
+ */
+@Composable
+fun PeriodPrivacyDialog(
+    onAccept: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.reminder_privacy_dialog_title)) },
+        text = { Text(stringResource(R.string.reminder_privacy_dialog_body)) },
+        confirmButton = {
+            TextButton(onClick = onAccept) {
+                Text(stringResource(R.string.reminder_privacy_dialog_accept))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.reminder_privacy_dialog_cancel))
+            }
+        }
+    )
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/ReminderSettings.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/ReminderSettings.kt
@@ -1,0 +1,394 @@
+package com.veleda.cyclewise.ui.settings
+
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.veleda.cyclewise.R
+import com.veleda.cyclewise.reminders.ReminderNotifier
+import com.veleda.cyclewise.reminders.ReminderScheduler
+import com.veleda.cyclewise.settings.AppSettings
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
+
+/**
+ * Standalone composable that renders the three reminder configuration sections:
+ * Period Prediction, Daily Medication, and Hydration.
+ *
+ * Each section has an enable/disable [Switch] plus type-specific settings that
+ * are only shown when the reminder is enabled. Toggling or changing any setting
+ * immediately schedules/cancels the corresponding WorkManager job via [reminderScheduler].
+ *
+ * On enabling any reminder on API 33+, the composable requests the POST_NOTIFICATIONS
+ * runtime permission. If denied, the toggle reverts and a rationale message is shown.
+ *
+ * @param appSettings       the [AppSettings] instance for reading/writing reminder preferences.
+ * @param reminderScheduler the [ReminderScheduler] instance for enqueuing/cancelling work.
+ */
+@Composable
+fun ReminderSettings(appSettings: AppSettings, reminderScheduler: ReminderScheduler) {
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    // --- Notification permission handling ---
+    var pendingEnableAction by remember { mutableStateOf<(() -> Unit)?>(null) }
+    var showPermissionRationale by remember { mutableStateOf(false) }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            pendingEnableAction?.invoke()
+        } else {
+            showPermissionRationale = true
+        }
+        pendingEnableAction = null
+    }
+
+    /**
+     * Ensures POST_NOTIFICATIONS permission is granted before executing [action].
+     * On API < 33, executes immediately. On API 33+, requests the permission first.
+     */
+    fun ensurePermissionThen(action: () -> Unit) {
+        if (ReminderNotifier.hasPermission(context)) {
+            action()
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pendingEnableAction = action
+            permissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
+    // --- State ---
+    val periodEnabled by appSettings.reminderPeriodEnabled.collectAsState(initial = false)
+    val periodDaysBefore by appSettings.reminderPeriodDaysBefore.collectAsState(initial = 2)
+    val periodPrivacyAccepted by appSettings.reminderPeriodPrivacyAccepted.collectAsState(initial = false)
+    var showPrivacyDialog by remember { mutableStateOf(false) }
+
+    val medicationEnabled by appSettings.reminderMedicationEnabled.collectAsState(initial = false)
+    val medicationHour by appSettings.reminderMedicationHour.collectAsState(initial = 9)
+    val medicationMinute by appSettings.reminderMedicationMinute.collectAsState(initial = 0)
+
+    val hydrationEnabled by appSettings.reminderHydrationEnabled.collectAsState(initial = false)
+    val hydrationGoalCups by appSettings.reminderHydrationGoalCups.collectAsState(initial = 8)
+    val hydrationFrequencyHours by appSettings.reminderHydrationFrequencyHours.collectAsState(initial = 3)
+    val hydrationStartHour by appSettings.reminderHydrationStartHour.collectAsState(initial = 8)
+    val hydrationEndHour by appSettings.reminderHydrationEndHour.collectAsState(initial = 20)
+
+    Column {
+        Text(
+            stringResource(R.string.reminder_settings_title),
+            style = MaterialTheme.typography.titleMedium
+        )
+        Spacer(Modifier.height(8.dp))
+
+        // ── Period Prediction ───────────────────────────────────────
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.reminder_period_label),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    stringResource(R.string.reminder_period_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = periodEnabled,
+                onCheckedChange = { checked ->
+                    if (checked) {
+                        ensurePermissionThen {
+                            if (periodPrivacyAccepted) {
+                                scope.launch {
+                                    appSettings.setReminderPeriodEnabled(true)
+                                    reminderScheduler.schedulePeriodPrediction(true)
+                                }
+                            } else {
+                                showPrivacyDialog = true
+                            }
+                        }
+                    } else {
+                        scope.launch {
+                            appSettings.setReminderPeriodEnabled(false)
+                            reminderScheduler.schedulePeriodPrediction(false)
+                        }
+                    }
+                }
+            )
+        }
+
+        if (periodEnabled) {
+            Spacer(Modifier.height(8.dp))
+            Text(stringResource(R.string.reminder_period_days_before_label, periodDaysBefore))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(1, 2, 3).forEach { days ->
+                    FilterChip(
+                        selected = periodDaysBefore == days,
+                        onClick = {
+                            scope.launch {
+                                appSettings.setReminderPeriodDaysBefore(days)
+                            }
+                        },
+                        label = { Text("$days") }
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // ── Daily Medication ────────────────────────────────────────
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.reminder_medication_label),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    stringResource(R.string.reminder_medication_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = medicationEnabled,
+                onCheckedChange = { checked ->
+                    if (checked) {
+                        ensurePermissionThen {
+                            scope.launch {
+                                appSettings.setReminderMedicationEnabled(true)
+                                reminderScheduler.scheduleMedication(true, medicationHour, medicationMinute)
+                            }
+                        }
+                    } else {
+                        scope.launch {
+                            appSettings.setReminderMedicationEnabled(false)
+                            reminderScheduler.scheduleMedication(false)
+                        }
+                    }
+                }
+            )
+        }
+
+        if (medicationEnabled) {
+            Spacer(Modifier.height(8.dp))
+            Text(stringResource(R.string.reminder_medication_time_label))
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    "%02d:%02d".format(medicationHour, medicationMinute),
+                    style = MaterialTheme.typography.titleLarge
+                )
+                Spacer(Modifier.width(8.dp))
+                Column {
+                    Text("Hour", style = MaterialTheme.typography.labelSmall)
+                    Slider(
+                        value = medicationHour.toFloat(),
+                        onValueChange = { newHour ->
+                            val hour = newHour.roundToInt()
+                            scope.launch {
+                                appSettings.setReminderMedicationHour(hour)
+                                reminderScheduler.scheduleMedication(true, hour, medicationMinute)
+                            }
+                        },
+                        valueRange = 0f..23f,
+                        steps = 22,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Column {
+                    Text("Minute", style = MaterialTheme.typography.labelSmall)
+                    Slider(
+                        value = medicationMinute.toFloat(),
+                        onValueChange = { newMinute ->
+                            val minute = newMinute.roundToInt()
+                            scope.launch {
+                                appSettings.setReminderMedicationMinute(minute)
+                                reminderScheduler.scheduleMedication(true, medicationHour, minute)
+                            }
+                        },
+                        valueRange = 0f..59f,
+                        steps = 58,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        // ── Hydration ───────────────────────────────────────────────
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    stringResource(R.string.reminder_hydration_label),
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    stringResource(R.string.reminder_hydration_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = hydrationEnabled,
+                onCheckedChange = { checked ->
+                    if (checked) {
+                        ensurePermissionThen {
+                            scope.launch {
+                                appSettings.setReminderHydrationEnabled(true)
+                                reminderScheduler.scheduleHydration(true, hydrationFrequencyHours)
+                            }
+                        }
+                    } else {
+                        scope.launch {
+                            appSettings.setReminderHydrationEnabled(false)
+                            reminderScheduler.scheduleHydration(false)
+                        }
+                    }
+                }
+            )
+        }
+
+        if (hydrationEnabled) {
+            Spacer(Modifier.height(8.dp))
+
+            // Goal cups
+            Text(stringResource(R.string.reminder_hydration_goal_label, hydrationGoalCups))
+            Slider(
+                value = hydrationGoalCups.toFloat(),
+                onValueChange = { newValue ->
+                    scope.launch { appSettings.setReminderHydrationGoalCups(newValue.roundToInt()) }
+                },
+                valueRange = 1f..20f,
+                steps = 18,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // Frequency
+            Spacer(Modifier.height(8.dp))
+            Text(stringResource(R.string.reminder_hydration_frequency_label))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(2, 3, 4).forEach { hours ->
+                    FilterChip(
+                        selected = hydrationFrequencyHours == hours,
+                        onClick = {
+                            scope.launch {
+                                appSettings.setReminderHydrationFrequencyHours(hours)
+                                reminderScheduler.scheduleHydration(true, hours)
+                            }
+                        },
+                        label = { Text("${hours}h") }
+                    )
+                }
+            }
+
+            // Active window
+            Spacer(Modifier.height(8.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.reminder_hydration_start_label))
+                    Slider(
+                        value = hydrationStartHour.toFloat(),
+                        onValueChange = { newValue ->
+                            scope.launch {
+                                appSettings.setReminderHydrationStartHour(newValue.roundToInt())
+                            }
+                        },
+                        valueRange = 0f..23f,
+                        steps = 22
+                    )
+                    Text("%02d:00".format(hydrationStartHour), style = MaterialTheme.typography.bodySmall)
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.reminder_hydration_end_label))
+                    Slider(
+                        value = hydrationEndHour.toFloat(),
+                        onValueChange = { newValue ->
+                            scope.launch {
+                                appSettings.setReminderHydrationEndHour(newValue.roundToInt())
+                            }
+                        },
+                        valueRange = 0f..23f,
+                        steps = 22
+                    )
+                    Text("%02d:00".format(hydrationEndHour), style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+
+        // --- Permission rationale ---
+        if (showPermissionRationale) {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                stringResource(R.string.reminder_permission_rationale),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+
+    // --- Privacy dialog ---
+    if (showPrivacyDialog) {
+        PeriodPrivacyDialog(
+            onAccept = {
+                showPrivacyDialog = false
+                scope.launch {
+                    appSettings.setReminderPeriodPrivacyAccepted(true)
+                    appSettings.setReminderPeriodEnabled(true)
+                    reminderScheduler.schedulePeriodPrediction(true)
+                }
+            },
+            onDismiss = {
+                showPrivacyDialog = false
+            }
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
@@ -157,6 +157,10 @@ fun SettingsScreen(navController: NavController) {
             HorizontalDivider()
             PhaseColorSettings(appSettings)
 
+            // --- Reminders Section ---
+            HorizontalDivider()
+            ReminderSettings(appSettings, getKoin().get())
+
             // --- Developer Options Section ---
             if (BuildConfig.DEBUG) {
                 HorizontalDivider()

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
@@ -10,12 +10,17 @@ import com.veleda.cyclewise.domain.providers.MedicationLibraryProvider
 import com.veleda.cyclewise.domain.providers.SymptomLibraryProvider
 import com.veleda.cyclewise.domain.repository.PeriodRepository
 import com.veleda.cyclewise.domain.usecases.AutoCloseOngoingPeriodUseCase
+import com.veleda.cyclewise.settings.AppSettings
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.daysUntil
+import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
+import kotlin.math.roundToInt
 import kotlin.time.Clock
 
 data class TrackerUiState(
@@ -51,7 +56,8 @@ class TrackerViewModel(
     private val periodRepository: PeriodRepository,
     private val symptomLibraryProvider: SymptomLibraryProvider,
     private  val medicationLibraryProvider: MedicationLibraryProvider,
-    private val autoClosePeriodUseCase: AutoCloseOngoingPeriodUseCase
+    private val autoClosePeriodUseCase: AutoCloseOngoingPeriodUseCase,
+    private val appSettings: AppSettings
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(TrackerUiState())
     val uiState: StateFlow<TrackerUiState> = _uiState.asStateFlow()
@@ -80,6 +86,7 @@ class TrackerViewModel(
         viewModelScope.launch {
             periodRepository.getAllPeriods().collect { periods ->
                 _uiState.update { it.copy(periods = periods) }
+                updatePredictionCache(periods)
             }
         }
 
@@ -186,5 +193,29 @@ class TrackerViewModel(
                 )
             }
         }
+    }
+
+    /**
+     * Caches the predicted next period date in [AppSettings] (plaintext DataStore)
+     * so the [PeriodPredictionWorker][com.veleda.cyclewise.reminders.workers.PeriodPredictionWorker]
+     * can access it without unlocking the encrypted database.
+     *
+     * Uses the same average-cycle-length algorithm as [InsightEngine]: computes the mean
+     * cycle length from completed periods and projects from the latest period's start date.
+     * Requires at least 2 completed periods. Clears the cache when insufficient data exists.
+     */
+    private suspend fun updatePredictionCache(periods: List<Period>) {
+        val completed = periods.filter { it.endDate != null }.sortedBy { it.startDate }
+        if (completed.size < 2) {
+            appSettings.setCachedPredictedPeriodDate("")
+            return
+        }
+        val cycleLengths = completed.zipWithNext { current, next ->
+            current.startDate.daysUntil(next.startDate).toDouble()
+        }
+        val avgDays = cycleLengths.average().roundToInt()
+        val latest = periods.maxBy { it.startDate }
+        val predicted = latest.startDate.plus(avgDays, DateTimeUnit.DAY)
+        appSettings.setCachedPredictedPeriodDate(predicted.toString())
     }
 }

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -36,4 +36,26 @@
     <string name="phase_color_reset_defaults">Reset to Defaults</string>
     <string name="phase_color_hex_hint">Hex (e.g. EF9A9A)</string>
     <string name="phase_color_invalid_hex">Invalid hex code</string>
+
+    <!-- Reminders -->
+    <string name="reminder_settings_title">Reminders</string>
+    <string name="reminder_period_label">Period Prediction</string>
+    <string name="reminder_period_description">Notify before your predicted next period</string>
+    <string name="reminder_period_days_before_label">Days before: %d</string>
+    <string name="reminder_medication_label">Daily Medication</string>
+    <string name="reminder_medication_description">A daily reminder at your chosen time</string>
+    <string name="reminder_medication_time_label">Reminder time</string>
+    <string name="reminder_hydration_label">Hydration</string>
+    <string name="reminder_hydration_description">Remind to log water during the day</string>
+    <string name="reminder_hydration_goal_label">Daily goal (cups): %d</string>
+    <string name="reminder_hydration_frequency_label">Reminder frequency</string>
+    <string name="reminder_hydration_start_label">Start hour</string>
+    <string name="reminder_hydration_end_label">End hour</string>
+    <string name="reminder_privacy_dialog_title">Privacy Notice</string>
+    <string name="reminder_privacy_dialog_body">Enabling this reminder stores your predicted period date in unencrypted local storage so background checks can run without your passphrase. Notifications may appear on your lock screen. No data leaves your device.</string>
+    <string name="reminder_privacy_dialog_accept">I Understand</string>
+    <string name="reminder_privacy_dialog_cancel">Cancel</string>
+    <string name="reminder_notification_title">RhythmWise</string>
+    <string name="reminder_notification_body">Time to check your app</string>
+    <string name="reminder_permission_rationale">Notification permission is needed to send reminders.</string>
 </resources>

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/ReminderNotifierTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/ReminderNotifierTest.kt
@@ -1,0 +1,96 @@
+package com.veleda.cyclewise.reminders
+
+import android.Manifest
+import android.app.Application
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowNotificationManager
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [ReminderNotifier] verifying notification channel creation,
+ * notification posting, and privacy-safe content.
+ *
+ * Tests that post notifications run on API 32 (pre-Tiramisu) to avoid
+ * the POST_NOTIFICATIONS runtime permission gate.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class ReminderNotifierTest {
+
+    private lateinit var context: Context
+    private lateinit var notificationManager: NotificationManager
+    private lateinit var shadowNotificationManager: ShadowNotificationManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        notificationManager = context.getSystemService(NotificationManager::class.java)
+        shadowNotificationManager = Shadows.shadowOf(notificationManager)
+    }
+
+    @Test
+    fun ensureChannel_WHEN_called_THEN_channelCreated() {
+        // GIVEN no channel exists yet
+        // WHEN
+        ReminderNotifier.ensureChannel(context)
+
+        // THEN
+        val channel = notificationManager.getNotificationChannel("reminders")
+        assertNotNull(channel, "Notification channel 'reminders' should exist")
+        assertEquals("Reminders", channel.name.toString())
+    }
+
+    @Test
+    @Config(sdk = [32])
+    fun notify_WHEN_permissionGranted_THEN_notificationPosted() {
+        // GIVEN channel exists and permission is granted (API 32 < Tiramisu, no runtime check)
+        ReminderNotifier.ensureChannel(context)
+
+        // WHEN
+        ReminderNotifier.notify(context, ReminderNotifier.NOTIFICATION_ID_PERIOD)
+
+        // THEN — verify notification was posted via shadow
+        assertTrue(
+            shadowNotificationManager.size() > 0,
+            "At least one notification should be posted"
+        )
+        val notification = shadowNotificationManager.getNotification(ReminderNotifier.NOTIFICATION_ID_PERIOD)
+        assertNotNull(notification, "Notification with NOTIFICATION_ID_PERIOD should be posted")
+    }
+
+    @Test
+    @Config(sdk = [32])
+    fun notify_WHEN_contentChecked_THEN_containsNoHealthData() {
+        // GIVEN (API 32, no runtime permission needed)
+        ReminderNotifier.ensureChannel(context)
+
+        // WHEN
+        ReminderNotifier.notify(context, ReminderNotifier.NOTIFICATION_ID_MEDICATION)
+
+        // THEN — verify static content contains no health-related keywords
+        val notification = shadowNotificationManager.getNotification(ReminderNotifier.NOTIFICATION_ID_MEDICATION)
+        assertNotNull(notification, "Notification should be posted")
+
+        val title = notification.extras.getString("android.title") ?: ""
+        val body = notification.extras.getString("android.text") ?: ""
+        val combined = "$title $body".lowercase()
+
+        val bannedKeywords = listOf("period", "ovulation", "medication", "bleeding", "menstrual", "cycle")
+        bannedKeywords.forEach { keyword ->
+            assertTrue(
+                keyword !in combined,
+                "Notification content must not contain health keyword '$keyword' — found in: '$combined'"
+            )
+        }
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/ReminderSchedulerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/ReminderSchedulerTest.kt
@@ -1,0 +1,118 @@
+package com.veleda.cyclewise.reminders
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.WorkManagerTestInitHelper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [ReminderScheduler] verifying that WorkManager jobs are
+ * correctly enqueued and cancelled.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class ReminderSchedulerTest {
+
+    private lateinit var context: Context
+    private lateinit var workManager: WorkManager
+    private lateinit var scheduler: ReminderScheduler
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        val config = Configuration.Builder()
+            .setMinimumLoggingLevel(android.util.Log.DEBUG)
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+        workManager = WorkManager.getInstance(context)
+        scheduler = ReminderScheduler(context)
+    }
+
+    @Test
+    fun schedulePeriodPrediction_WHEN_enabled_THEN_enqueuesPeriodicWork() {
+        // WHEN
+        scheduler.schedulePeriodPrediction(true)
+
+        // THEN
+        val workInfos = workManager.getWorkInfosForUniqueWork(ReminderScheduler.WORK_NAME_PERIOD).get()
+        assertTrue(workInfos.isNotEmpty(), "Period prediction work should be enqueued")
+        assertEquals(WorkInfo.State.ENQUEUED, workInfos.first().state)
+    }
+
+    @Test
+    fun schedulePeriodPrediction_WHEN_disabled_THEN_cancelsWork() {
+        // GIVEN work was previously scheduled
+        scheduler.schedulePeriodPrediction(true)
+
+        // WHEN
+        scheduler.schedulePeriodPrediction(false)
+
+        // THEN
+        val workInfos = workManager.getWorkInfosForUniqueWork(ReminderScheduler.WORK_NAME_PERIOD).get()
+        assertTrue(
+            workInfos.isEmpty() || workInfos.all { it.state == WorkInfo.State.CANCELLED },
+            "Period prediction work should be cancelled"
+        )
+    }
+
+    @Test
+    fun scheduleMedication_WHEN_enabled_THEN_enqueuesPeriodicWork() {
+        // WHEN
+        scheduler.scheduleMedication(true, 9, 0)
+
+        // THEN
+        val workInfos = workManager.getWorkInfosForUniqueWork(ReminderScheduler.WORK_NAME_MEDICATION).get()
+        assertTrue(workInfos.isNotEmpty(), "Medication work should be enqueued")
+        assertEquals(WorkInfo.State.ENQUEUED, workInfos.first().state)
+    }
+
+    @Test
+    fun scheduleHydration_WHEN_enabled_THEN_enqueuesPeriodicWorkWithCorrectInterval() {
+        // WHEN
+        scheduler.scheduleHydration(true, 3)
+
+        // THEN
+        val workInfos = workManager.getWorkInfosForUniqueWork(ReminderScheduler.WORK_NAME_HYDRATION).get()
+        assertTrue(workInfos.isNotEmpty(), "Hydration work should be enqueued")
+        val state = workInfos.first().state
+        assertTrue(
+            state == WorkInfo.State.ENQUEUED || state == WorkInfo.State.RUNNING,
+            "Hydration work should be enqueued or running, was: $state"
+        )
+    }
+
+    @Test
+    fun cancelAll_WHEN_called_THEN_cancelsAllThreeWorkNames() {
+        // GIVEN all three are scheduled
+        scheduler.schedulePeriodPrediction(true)
+        scheduler.scheduleMedication(true, 9, 0)
+        scheduler.scheduleHydration(true, 3)
+
+        // WHEN
+        scheduler.cancelAll()
+
+        // THEN
+        listOf(
+            ReminderScheduler.WORK_NAME_PERIOD,
+            ReminderScheduler.WORK_NAME_MEDICATION,
+            ReminderScheduler.WORK_NAME_HYDRATION
+        ).forEach { workName ->
+            val workInfos = workManager.getWorkInfosForUniqueWork(workName).get()
+            assertTrue(
+                workInfos.isEmpty() || workInfos.all { it.state == WorkInfo.State.CANCELLED },
+                "Work '$workName' should be cancelled"
+            )
+        }
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/workers/HydrationReminderWorkerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/workers/HydrationReminderWorkerTest.kt
@@ -1,0 +1,98 @@
+package com.veleda.cyclewise.reminders.workers
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.veleda.cyclewise.androidData.local.draft.LockedWaterDraft
+import com.veleda.cyclewise.settings.AppSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+
+/**
+ * Unit tests for [HydrationReminderWorker] verifying notification behavior
+ * based on active window, goal, and current water intake.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class HydrationReminderWorkerTest {
+
+    private lateinit var context: Context
+    private lateinit var appSettings: AppSettings
+    private lateinit var lockedWaterDraft: LockedWaterDraft
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        appSettings = AppSettings(context)
+        lockedWaterDraft = LockedWaterDraft(context)
+    }
+
+    @Test
+    fun doWork_WHEN_withinWindowAndBelowGoal_THEN_succeeds() = runTest {
+        // GIVEN active window covers the current hour, goal not met
+        val currentHour = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
+        appSettings.setReminderHydrationStartHour(0)
+        appSettings.setReminderHydrationEndHour(23)
+        appSettings.setReminderHydrationGoalCups(10)
+
+        // No water logged today (default)
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+        lockedWaterDraft.setCups(today, 0)
+
+        // WHEN
+        val worker = TestListenableWorkerBuilder<HydrationReminderWorker>(context).build()
+        val result = worker.doWork()
+
+        // THEN — succeeds (notification would be posted)
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun doWork_WHEN_outsideWindow_THEN_succeeds_noNotification() = runTest {
+        // GIVEN active window does NOT cover the current hour
+        // Set window to a time range that's guaranteed to exclude now
+        val currentHour = java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY)
+        val startHour = (currentHour + 2) % 24
+        val endHour = (currentHour + 3) % 24
+
+        appSettings.setReminderHydrationStartHour(startHour)
+        appSettings.setReminderHydrationEndHour(if (endHour > startHour) endHour else 23)
+        appSettings.setReminderHydrationGoalCups(8)
+
+        // WHEN
+        val worker = TestListenableWorkerBuilder<HydrationReminderWorker>(context).build()
+        val result = worker.doWork()
+
+        // THEN — succeeds silently
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun doWork_WHEN_goalMet_THEN_succeeds_noNotification() = runTest {
+        // GIVEN goal is met (logged enough cups)
+        appSettings.setReminderHydrationStartHour(0)
+        appSettings.setReminderHydrationEndHour(23)
+        appSettings.setReminderHydrationGoalCups(8)
+
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+        lockedWaterDraft.setCups(today, 10) // 10 cups logged, goal is 8
+
+        // WHEN
+        val worker = TestListenableWorkerBuilder<HydrationReminderWorker>(context).build()
+        val result = worker.doWork()
+
+        // THEN — succeeds silently (goal met, no notification)
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/workers/MedicationReminderWorkerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/workers/MedicationReminderWorkerTest.kt
@@ -1,0 +1,45 @@
+package com.veleda.cyclewise.reminders.workers
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+/**
+ * Unit tests for [MedicationReminderWorker].
+ *
+ * The worker simply posts a notification on every execution — scheduling
+ * (including time-of-day targeting) is handled by [ReminderScheduler].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class MedicationReminderWorkerTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun doWork_WHEN_called_THEN_succeeds() = runTest {
+        // GIVEN a medication reminder worker
+        val worker = TestListenableWorkerBuilder<MedicationReminderWorker>(context).build()
+
+        // WHEN
+        val result = worker.doWork()
+
+        // THEN — always succeeds
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/workers/PeriodPredictionWorkerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/reminders/workers/PeriodPredictionWorkerTest.kt
@@ -1,0 +1,101 @@
+package com.veleda.cyclewise.reminders.workers
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.veleda.cyclewise.settings.AppSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.minus
+import kotlinx.datetime.plus
+import kotlinx.datetime.todayIn
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+
+/**
+ * Unit tests for [PeriodPredictionWorker] verifying notification behavior
+ * based on cached prediction date and days-before window.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class PeriodPredictionWorkerTest {
+
+    private lateinit var context: Context
+    private lateinit var appSettings: AppSettings
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        appSettings = AppSettings(context)
+    }
+
+    @Test
+    fun doWork_WHEN_cachedDateWithinWindow_THEN_succeeds() = runTest {
+        // GIVEN predicted date is 1 day from now, days-before window is 2
+        val tomorrow = Clock.System.todayIn(TimeZone.currentSystemDefault())
+            .plus(1, DateTimeUnit.DAY)
+        appSettings.setCachedPredictedPeriodDate(tomorrow.toString())
+        appSettings.setReminderPeriodDaysBefore(2)
+
+        // WHEN
+        val worker = TestListenableWorkerBuilder<PeriodPredictionWorker>(context).build()
+        val result = worker.doWork()
+
+        // THEN — worker succeeds (notification would be posted)
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun doWork_WHEN_cachedDateBlank_THEN_succeeds_noNotification() = runTest {
+        // GIVEN no cached date
+        appSettings.setCachedPredictedPeriodDate("")
+
+        // WHEN
+        val worker = TestListenableWorkerBuilder<PeriodPredictionWorker>(context).build()
+        val result = worker.doWork()
+
+        // THEN — succeeds silently
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun doWork_WHEN_cachedDateInPast_THEN_succeeds_noNotification() = runTest {
+        // GIVEN predicted date is 5 days in the past
+        val pastDate = Clock.System.todayIn(TimeZone.currentSystemDefault())
+            .minus(5, DateTimeUnit.DAY)
+        appSettings.setCachedPredictedPeriodDate(pastDate.toString())
+        appSettings.setReminderPeriodDaysBefore(2)
+
+        // WHEN
+        val worker = TestListenableWorkerBuilder<PeriodPredictionWorker>(context).build()
+        val result = worker.doWork()
+
+        // THEN — succeeds silently (negative daysUntil is outside window)
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+
+    @Test
+    fun doWork_WHEN_cachedDateTooFarAway_THEN_succeeds_noNotification() = runTest {
+        // GIVEN predicted date is 10 days from now, days-before window is 3
+        val farDate = Clock.System.todayIn(TimeZone.currentSystemDefault())
+            .plus(10, DateTimeUnit.DAY)
+        appSettings.setCachedPredictedPeriodDate(farDate.toString())
+        appSettings.setReminderPeriodDaysBefore(3)
+
+        // WHEN
+        val worker = TestListenableWorkerBuilder<PeriodPredictionWorker>(context).build()
+        val result = worker.doWork()
+
+        // THEN — succeeds silently (10 is outside 0..3 window)
+        assertEquals(ListenableWorker.Result.success(), result)
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/settings/AppSettingsReminderTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/settings/AppSettingsReminderTest.kt
@@ -1,0 +1,395 @@
+package com.veleda.cyclewise.settings
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the reminder-related preferences in [AppSettings].
+ *
+ * Follows the same pattern as [AppSettingsTest]: Robolectric + Turbine,
+ * Given-When-Then structure, roundtrip set/read verification.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class AppSettingsReminderTest {
+
+    private lateinit var appSettings: AppSettings
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        appSettings = AppSettings(context)
+    }
+
+    // --- reminderPeriodEnabled ---
+
+    @Test
+    fun setReminderPeriodEnabled_WHEN_setToTrue_THEN_emitsTrue() = runTest {
+        appSettings.setReminderPeriodEnabled(false)
+
+        appSettings.reminderPeriodEnabled.test {
+            assertFalse(awaitItem())
+
+            appSettings.setReminderPeriodEnabled(true)
+
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderPeriodEnabled_WHEN_setToFalse_THEN_emitsFalse() = runTest {
+        appSettings.setReminderPeriodEnabled(true)
+
+        appSettings.reminderPeriodEnabled.test {
+            assertTrue(awaitItem())
+
+            appSettings.setReminderPeriodEnabled(false)
+
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderPeriodDaysBefore ---
+
+    @Test
+    fun setReminderPeriodDaysBefore_WHEN_setTo1_THEN_emits1() = runTest {
+        appSettings.setReminderPeriodDaysBefore(2)
+
+        appSettings.reminderPeriodDaysBefore.test {
+            assertEquals(2, awaitItem())
+
+            appSettings.setReminderPeriodDaysBefore(1)
+
+            assertEquals(1, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderPeriodDaysBefore_WHEN_setTo3_THEN_emits3() = runTest {
+        appSettings.setReminderPeriodDaysBefore(2)
+
+        appSettings.reminderPeriodDaysBefore.test {
+            assertEquals(2, awaitItem())
+
+            appSettings.setReminderPeriodDaysBefore(3)
+
+            assertEquals(3, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderPeriodPrivacyAccepted ---
+
+    @Test
+    fun setReminderPeriodPrivacyAccepted_WHEN_setToTrue_THEN_emitsTrue() = runTest {
+        appSettings.setReminderPeriodPrivacyAccepted(false)
+
+        appSettings.reminderPeriodPrivacyAccepted.test {
+            assertFalse(awaitItem())
+
+            appSettings.setReminderPeriodPrivacyAccepted(true)
+
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderPeriodPrivacyAccepted_WHEN_setToFalse_THEN_emitsFalse() = runTest {
+        appSettings.setReminderPeriodPrivacyAccepted(true)
+
+        appSettings.reminderPeriodPrivacyAccepted.test {
+            assertTrue(awaitItem())
+
+            appSettings.setReminderPeriodPrivacyAccepted(false)
+
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderMedicationEnabled ---
+
+    @Test
+    fun setReminderMedicationEnabled_WHEN_setToTrue_THEN_emitsTrue() = runTest {
+        appSettings.setReminderMedicationEnabled(false)
+
+        appSettings.reminderMedicationEnabled.test {
+            assertFalse(awaitItem())
+
+            appSettings.setReminderMedicationEnabled(true)
+
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderMedicationEnabled_WHEN_setToFalse_THEN_emitsFalse() = runTest {
+        appSettings.setReminderMedicationEnabled(true)
+
+        appSettings.reminderMedicationEnabled.test {
+            assertTrue(awaitItem())
+
+            appSettings.setReminderMedicationEnabled(false)
+
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderMedicationHour ---
+
+    @Test
+    fun setReminderMedicationHour_WHEN_setTo14_THEN_emits14() = runTest {
+        appSettings.setReminderMedicationHour(9)
+
+        appSettings.reminderMedicationHour.test {
+            assertEquals(9, awaitItem())
+
+            appSettings.setReminderMedicationHour(14)
+
+            assertEquals(14, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderMedicationHour_WHEN_setTo0_THEN_emits0() = runTest {
+        appSettings.setReminderMedicationHour(9)
+
+        appSettings.reminderMedicationHour.test {
+            assertEquals(9, awaitItem())
+
+            appSettings.setReminderMedicationHour(0)
+
+            assertEquals(0, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderMedicationMinute ---
+
+    @Test
+    fun setReminderMedicationMinute_WHEN_setTo30_THEN_emits30() = runTest {
+        appSettings.setReminderMedicationMinute(0)
+
+        appSettings.reminderMedicationMinute.test {
+            assertEquals(0, awaitItem())
+
+            appSettings.setReminderMedicationMinute(30)
+
+            assertEquals(30, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderMedicationMinute_WHEN_setTo45_THEN_emits45() = runTest {
+        appSettings.setReminderMedicationMinute(0)
+
+        appSettings.reminderMedicationMinute.test {
+            assertEquals(0, awaitItem())
+
+            appSettings.setReminderMedicationMinute(45)
+
+            assertEquals(45, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderHydrationEnabled ---
+
+    @Test
+    fun setReminderHydrationEnabled_WHEN_setToTrue_THEN_emitsTrue() = runTest {
+        appSettings.setReminderHydrationEnabled(false)
+
+        appSettings.reminderHydrationEnabled.test {
+            assertFalse(awaitItem())
+
+            appSettings.setReminderHydrationEnabled(true)
+
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderHydrationEnabled_WHEN_setToFalse_THEN_emitsFalse() = runTest {
+        appSettings.setReminderHydrationEnabled(true)
+
+        appSettings.reminderHydrationEnabled.test {
+            assertTrue(awaitItem())
+
+            appSettings.setReminderHydrationEnabled(false)
+
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderHydrationGoalCups ---
+
+    @Test
+    fun setReminderHydrationGoalCups_WHEN_setTo12_THEN_emits12() = runTest {
+        appSettings.setReminderHydrationGoalCups(8)
+
+        appSettings.reminderHydrationGoalCups.test {
+            assertEquals(8, awaitItem())
+
+            appSettings.setReminderHydrationGoalCups(12)
+
+            assertEquals(12, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderHydrationGoalCups_WHEN_setTo4_THEN_emits4() = runTest {
+        appSettings.setReminderHydrationGoalCups(8)
+
+        appSettings.reminderHydrationGoalCups.test {
+            assertEquals(8, awaitItem())
+
+            appSettings.setReminderHydrationGoalCups(4)
+
+            assertEquals(4, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderHydrationFrequencyHours ---
+
+    @Test
+    fun setReminderHydrationFrequencyHours_WHEN_setTo2_THEN_emits2() = runTest {
+        appSettings.setReminderHydrationFrequencyHours(3)
+
+        appSettings.reminderHydrationFrequencyHours.test {
+            assertEquals(3, awaitItem())
+
+            appSettings.setReminderHydrationFrequencyHours(2)
+
+            assertEquals(2, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderHydrationFrequencyHours_WHEN_setTo4_THEN_emits4() = runTest {
+        appSettings.setReminderHydrationFrequencyHours(3)
+
+        appSettings.reminderHydrationFrequencyHours.test {
+            assertEquals(3, awaitItem())
+
+            appSettings.setReminderHydrationFrequencyHours(4)
+
+            assertEquals(4, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderHydrationStartHour ---
+
+    @Test
+    fun setReminderHydrationStartHour_WHEN_setTo6_THEN_emits6() = runTest {
+        appSettings.setReminderHydrationStartHour(8)
+
+        appSettings.reminderHydrationStartHour.test {
+            assertEquals(8, awaitItem())
+
+            appSettings.setReminderHydrationStartHour(6)
+
+            assertEquals(6, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderHydrationStartHour_WHEN_setTo10_THEN_emits10() = runTest {
+        appSettings.setReminderHydrationStartHour(8)
+
+        appSettings.reminderHydrationStartHour.test {
+            assertEquals(8, awaitItem())
+
+            appSettings.setReminderHydrationStartHour(10)
+
+            assertEquals(10, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- reminderHydrationEndHour ---
+
+    @Test
+    fun setReminderHydrationEndHour_WHEN_setTo18_THEN_emits18() = runTest {
+        appSettings.setReminderHydrationEndHour(20)
+
+        appSettings.reminderHydrationEndHour.test {
+            assertEquals(20, awaitItem())
+
+            appSettings.setReminderHydrationEndHour(18)
+
+            assertEquals(18, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setReminderHydrationEndHour_WHEN_setTo22_THEN_emits22() = runTest {
+        appSettings.setReminderHydrationEndHour(20)
+
+        appSettings.reminderHydrationEndHour.test {
+            assertEquals(20, awaitItem())
+
+            appSettings.setReminderHydrationEndHour(22)
+
+            assertEquals(22, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // --- cachedPredictedPeriodDate ---
+
+    @Test
+    fun setCachedPredictedPeriodDate_WHEN_setToIsoDate_THEN_emitsIsoDate() = runTest {
+        appSettings.setCachedPredictedPeriodDate("")
+
+        appSettings.cachedPredictedPeriodDate.test {
+            assertEquals("", awaitItem())
+
+            appSettings.setCachedPredictedPeriodDate("2026-03-15")
+
+            assertEquals("2026-03-15", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun setCachedPredictedPeriodDate_WHEN_clearedToEmpty_THEN_emitsEmpty() = runTest {
+        appSettings.setCachedPredictedPeriodDate("2026-03-15")
+
+        appSettings.cachedPredictedPeriodDate.test {
+            assertEquals("2026-03-15", awaitItem())
+
+            appSettings.setCachedPredictedPeriodDate("")
+
+            assertEquals("", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/tracker/CycleViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/tracker/CycleViewModelTest.kt
@@ -7,6 +7,7 @@ import com.veleda.cyclewise.domain.providers.MedicationLibraryProvider
 import com.veleda.cyclewise.domain.providers.SymptomLibraryProvider
 import com.veleda.cyclewise.domain.repository.PeriodRepository
 import com.veleda.cyclewise.domain.usecases.AutoCloseOngoingPeriodUseCase
+import com.veleda.cyclewise.settings.AppSettings
 import com.veleda.cyclewise.testutil.TestData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,6 +36,7 @@ class CycleViewModelTest {
     private lateinit var mockSymptomProvider: SymptomLibraryProvider
     private lateinit var mockMedicationProvider: MedicationLibraryProvider
     private lateinit var mockAutoCloseUseCase: AutoCloseOngoingPeriodUseCase
+    private lateinit var mockAppSettings: AppSettings
     private lateinit var viewModel: TrackerViewModel
 
     @Before
@@ -45,13 +47,14 @@ class CycleViewModelTest {
         mockSymptomProvider = mockk(relaxed = true)
         mockMedicationProvider = mockk(relaxed = true)
         mockAutoCloseUseCase = mockk(relaxed = true)
+        mockAppSettings = mockk(relaxed = true)
 
         every { mockRepository.observeDayDetails() } returns flowOf(emptyMap())
         every { mockRepository.getAllPeriods() } returns flowOf(emptyList())
         every { mockSymptomProvider.symptoms } returns flowOf(emptyList())
         every { mockMedicationProvider.medications } returns flowOf(emptyList())
 
-        viewModel = TrackerViewModel(mockRepository, mockSymptomProvider, mockMedicationProvider, mockAutoCloseUseCase)
+        viewModel = TrackerViewModel(mockRepository, mockSymptomProvider, mockMedicationProvider, mockAutoCloseUseCase, mockAppSettings)
     }
 
     @After
@@ -99,7 +102,7 @@ class CycleViewModelTest {
         val fakeLog = FullDailyLog(DailyEntry("log-id", pastDate, 5, createdAt = TestData.INSTANT, updatedAt = TestData.INSTANT))
 
         every { mockRepository.getAllPeriods() } returns flowOf(listOf(fakePeriod))
-        viewModel = TrackerViewModel(mockRepository, mockSymptomProvider, mockMedicationProvider, mockAutoCloseUseCase)
+        viewModel = TrackerViewModel(mockRepository, mockSymptomProvider, mockMedicationProvider, mockAutoCloseUseCase, mockAppSettings)
         advanceUntilIdle()
 
         coEvery { mockRepository.getFullLogForDate(pastDate) } returns fakeLog

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ junitVersion = "4.13.2"
 androidx-arch-core = "2.2.0"
 robolectric = "4.16"
 turbine = "1.2.1"
+workmanager = "2.10.1"
 bouncy = "1.81"
 androidx-test-core = "1.7.0"
 encoding = "2.4.0"
@@ -84,6 +85,9 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 encoding-base64 = { module = "io.matthewnelson.encoding:base64", version.ref = "encoding" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+
+workmanager-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "workmanager" }
+workmanager-testing = { module = "androidx.work:work-testing", version.ref = "workmanager" }
 
 # --- ANDROIDX TEST ---
 androidx-test-core = { module = "androidx.test:core-ktx", version.ref = "androidx-test" } # This should exist


### PR DESCRIPTION
  Implement three privacy-safe reminder types (period prediction,
  daily medication, hydration) using WorkManager periodic jobs.

  All notifications use static, generic content with no health data
  exposed. Workers read settings from plaintext DataStore to avoid
  requiring the encrypted database passphrase.

  - Add 12 new AppSettings preferences for reminder configuration
  - Add ReminderNotifier singleton for channel/notification management
  - Add PeriodPredictionWorker, MedicationReminderWorker, HydrationReminderWorker
  - Add ReminderScheduler coordinator for WorkManager job lifecycle
  - Cache predicted period date in TrackerViewModel for worker access
  - Add ReminderSettings composable with privacy dialog for period reminders
  - Add POST_NOTIFICATIONS permission and runtime permission flow
  - Add unit tests for all new components (24 AppSettings roundtrip tests, 3 notifier tests, 8 worker tests, 5 scheduler tests)

  Signed-off-by: Daniel Simmons SmileyBob72801@gmail.com