### PR TITLE
feat(settings): add three-way theme toggle (System / Light / Dark)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/settings/AppSettings.kt
@@ -36,6 +36,7 @@ private val REMINDER_HYDRATION_FREQUENCY_HOURS = intPreferencesKey("reminder_hyd
 private val REMINDER_HYDRATION_START_HOUR = intPreferencesKey("reminder_hydration_start_hour")
 private val REMINDER_HYDRATION_END_HOUR = intPreferencesKey("reminder_hydration_end_hour")
 private val CACHED_PREDICTED_PERIOD_DATE = stringPreferencesKey("cached_predicted_period_date")
+private val THEME_MODE = stringPreferencesKey("theme_mode")
 
 /**
  * DataStore-backed wrapper for user-configurable app preferences.
@@ -68,6 +69,7 @@ private val CACHED_PREDICTED_PERIOD_DATE = stringPreferencesKey("cached_predicte
  * @property reminderHydrationStartHour     Active window start hour (0–23, default: 8).
  * @property reminderHydrationEndHour       Active window end hour (0–23, default: 20).
  * @property cachedPredictedPeriodDate      ISO date cache for the period prediction worker (e.g. "2026-03-15").
+ * @property themeMode                     User-selected theme mode key ("system", "light", or "dark"; default: "system").
  */
 class AppSettings(private val context: Context) {
     val autolockMinutes = context.dataStore.data.map { prefs -> prefs[AUTOLOCK_MIN] ?: 10 }
@@ -293,5 +295,16 @@ class AppSettings(private val context: Context) {
     /** Persists the cached predicted period date for the background worker. */
     suspend fun setCachedPredictedPeriodDate(date: String) {
         context.dataStore.edit { it[CACHED_PREDICTED_PERIOD_DATE] = date }
+    }
+
+    // ── Theme preferences ─────────────────────────────────────────────
+
+    /** User-selected theme mode key ("system", "light", or "dark"). */
+    val themeMode: Flow<String> = context.dataStore.data
+        .map { prefs -> prefs[THEME_MODE] ?: "system" }
+
+    /** Persists the user's selected theme mode. */
+    suspend fun setThemeMode(mode: String) {
+        context.dataStore.edit { it[THEME_MODE] = mode }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -28,12 +30,15 @@ import com.veleda.cyclewise.ui.log.DailyLogScreen
 import com.veleda.cyclewise.ui.nav.BottomNavBar
 import com.veleda.cyclewise.ui.nav.NavRoute
 import com.veleda.cyclewise.ui.settings.SettingsScreen
+import com.veleda.cyclewise.ui.settings.SettingsViewModel
 import com.veleda.cyclewise.ui.theme.RhythmWiseTheme
+import com.veleda.cyclewise.ui.theme.ThemeMode
 import com.veleda.cyclewise.ui.tracker.TrackerScreen
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.androidx.compose.koinViewModel
 import kotlin.time.Clock
 
 /** Duration (ms) for default bottom-nav tab crossfade transitions. */
@@ -48,7 +53,15 @@ private const val AUTH_TRANSITION_DURATION_MS = 400
 @Composable
 @Preview
 fun CycleWiseAppUI() {
-    RhythmWiseTheme {
+    val settingsViewModel: SettingsViewModel = koinViewModel()
+    val settingsState by settingsViewModel.uiState.collectAsState()
+    val darkTheme = when (settingsState.themeMode) {
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+    }
+
+    RhythmWiseTheme(darkTheme = darkTheme) {
         val navController = rememberNavController()
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsEvent.kt
@@ -1,5 +1,7 @@
 package com.veleda.cyclewise.ui.settings
 
+import com.veleda.cyclewise.ui.theme.ThemeMode
+
 /**
  * All events that can be dispatched to [SettingsViewModel.onEvent].
  *
@@ -31,6 +33,11 @@ sealed interface SettingsEvent {
 
     /** User toggled "Show Libido in summary". */
     data class ShowLibidoToggled(val enabled: Boolean) : SettingsEvent
+
+    // ── Theme ─────────────────────────────────────────────────────────
+
+    /** User selected a new theme mode from the segmented button row. */
+    data class ThemeModeChanged(val mode: ThemeMode) : SettingsEvent
 
     // ── Phase visibility toggles ─────────────────────────────────────
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
@@ -56,6 +56,7 @@ import com.veleda.cyclewise.R
 import com.veleda.cyclewise.domain.usecases.DebugSeederUseCase
 import com.veleda.cyclewise.ui.nav.NavRoute
 import com.veleda.cyclewise.ui.theme.LocalDimensions
+import com.veleda.cyclewise.ui.theme.ThemeMode
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.getKoin
@@ -302,6 +303,36 @@ private fun AppearancePage(
         verticalArrangement = Arrangement.spacedBy(dims.md)
     ) {
         Spacer(Modifier.height(dims.sm))
+
+        // ── Theme Card ───────────────────────────────────────────────
+        SettingsSectionCard(title = stringResource(R.string.settings_section_theme)) {
+            val modes = ThemeMode.entries
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = dims.md)
+            ) {
+                modes.forEachIndexed { index, mode ->
+                    SegmentedButton(
+                        shape = SegmentedButtonDefaults.itemShape(
+                            index = index,
+                            count = modes.size
+                        ),
+                        onClick = { onEvent(SettingsEvent.ThemeModeChanged(mode)) },
+                        selected = uiState.themeMode == mode,
+                        label = {
+                            Text(
+                                when (mode) {
+                                    ThemeMode.SYSTEM -> stringResource(R.string.theme_mode_system)
+                                    ThemeMode.LIGHT -> stringResource(R.string.theme_mode_light)
+                                    ThemeMode.DARK -> stringResource(R.string.theme_mode_dark)
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+        }
 
         // ── Display Card ─────────────────────────────────────────────
         SettingsSectionCard(title = stringResource(R.string.settings_section_display)) {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.veleda.cyclewise.reminders.ReminderScheduler
 import com.veleda.cyclewise.settings.AppSettings
+import com.veleda.cyclewise.ui.theme.ThemeMode
 import com.veleda.cyclewise.ui.tracker.CyclePhaseColors
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +21,7 @@ import kotlinx.coroutines.launch
  * Dialog visibility flags (about, privacy, permission rationale) are also managed here
  * instead of via local `remember { mutableStateOf() }` to keep state centralized.
  *
+ * @property themeMode                 User-selected theme mode (default [ThemeMode.SYSTEM]).
  * @property autolockMinutes          Auto-lock timeout in minutes (default 10).
  * @property topSymptomsCount         Number of top symptoms shown in insights (default 3).
  * @property showMood                 Whether mood is shown in the daily log summary.
@@ -48,6 +50,7 @@ import kotlinx.coroutines.launch
  * @property showPermissionRationale  Whether the notification permission rationale is shown.
  */
 data class SettingsUiState(
+    val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val autolockMinutes: Int = 10,
     val topSymptomsCount: Int = 3,
     val showMood: Boolean = true,
@@ -103,6 +106,10 @@ class SettingsViewModel(
     init {
         // Collect each AppSettings flow individually to populate state.
         // This avoids the 22+ param combine() limitation.
+        appSettings.themeMode
+            .onEach { value -> _uiState.update { it.copy(themeMode = ThemeMode.fromKey(value)) } }
+            .launchIn(viewModelScope)
+
         appSettings.autolockMinutes
             .onEach { value -> _uiState.update { it.copy(autolockMinutes = value) } }
             .launchIn(viewModelScope)
@@ -207,6 +214,10 @@ class SettingsViewModel(
 
         // Side effects: persist to DataStore and schedule/cancel reminders.
         when (event) {
+            is SettingsEvent.ThemeModeChanged -> viewModelScope.launch {
+                appSettings.setThemeMode(event.mode.key)
+            }
+
             is SettingsEvent.AutolockChanged -> viewModelScope.launch {
                 appSettings.setAutolockMinutes(event.minutes)
             }
@@ -348,6 +359,7 @@ class SettingsViewModel(
      */
     private fun reduce(state: SettingsUiState, event: SettingsEvent): SettingsUiState {
         return when (event) {
+            is SettingsEvent.ThemeModeChanged -> state.copy(themeMode = event.mode)
             is SettingsEvent.AutolockChanged -> state.copy(autolockMinutes = event.minutes)
             is SettingsEvent.TopSymptomsCountChanged -> state.copy(topSymptomsCount = event.count)
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/theme/ThemeMode.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/theme/ThemeMode.kt
@@ -1,0 +1,20 @@
+package com.veleda.cyclewise.ui.theme
+
+/**
+ * User-selectable theme mode, persisted to DataStore as a [key] string.
+ *
+ * - [SYSTEM] — follow the device's dark/light setting (default).
+ * - [LIGHT]  — always use the light color scheme.
+ * - [DARK]   — always use the dark color scheme.
+ */
+enum class ThemeMode(val key: String) {
+    SYSTEM("system"),
+    LIGHT("light"),
+    DARK("dark");
+
+    companion object {
+        /** Resolves a [key] back to a [ThemeMode], falling back to [SYSTEM] for unknown values. */
+        fun fromKey(key: String): ThemeMode =
+            entries.firstOrNull { it.key == key } ?: SYSTEM
+    }
+}

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -136,6 +136,10 @@
     <string name="settings_section_display">Display</string>
     <string name="settings_section_customization">Customization</string>
     <string name="settings_section_notifications">Notifications</string>
+    <string name="settings_section_theme">Theme</string>
+    <string name="theme_mode_system">System</string>
+    <string name="theme_mode_light">Light</string>
+    <string name="theme_mode_dark">Dark</string>
     <string name="settings_page_general">General</string>
     <string name="settings_page_appearance">Appearance</string>
     <string name="settings_page_notifications">Notifications</string>

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModelTest.kt
@@ -3,6 +3,7 @@ package com.veleda.cyclewise.ui.settings
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.veleda.cyclewise.reminders.ReminderScheduler
 import com.veleda.cyclewise.settings.AppSettings
+import com.veleda.cyclewise.ui.theme.ThemeMode
 import com.veleda.cyclewise.ui.tracker.CyclePhaseColors
 import io.mockk.coVerify
 import io.mockk.every
@@ -49,6 +50,7 @@ class SettingsViewModelTest {
         mockReminderScheduler = mockk(relaxed = true)
 
         // Configure all AppSettings flows to return defaults.
+        every { mockAppSettings.themeMode } returns flowOf("system")
         every { mockAppSettings.autolockMinutes } returns flowOf(10)
         every { mockAppSettings.topSymptomsCount } returns flowOf(3)
         every { mockAppSettings.showMoodInSummary } returns flowOf(true)
@@ -97,6 +99,7 @@ class SettingsViewModelTest {
 
         // THEN — state matches defaults
         val state = viewModel.uiState.value
+        assertEquals(ThemeMode.SYSTEM, state.themeMode)
         assertEquals(10, state.autolockMinutes)
         assertEquals(3, state.topSymptomsCount)
         assertTrue(state.showMood)
@@ -452,5 +455,35 @@ class SettingsViewModelTest {
         coVerify(atLeast = 1) { mockAppSettings.setReminderPeriodPrivacyAccepted(true) }
         coVerify(atLeast = 1) { mockAppSettings.setReminderPeriodEnabled(true) }
         verify(atLeast = 1) { mockReminderScheduler.schedulePeriodPrediction(true) }
+    }
+
+    // ── Theme mode ──────────────────────────────────────────────────
+
+    @Test
+    fun `onEvent ThemeModeChanged WHEN dark THEN updatesStateAndPersists`() = runTest {
+        // GIVEN — ViewModel with defaults (themeMode = SYSTEM)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — theme mode changed to DARK
+        viewModel.onEvent(SettingsEvent.ThemeModeChanged(ThemeMode.DARK))
+        advanceUntilIdle()
+
+        // THEN — state updated and persistence called
+        assertEquals(ThemeMode.DARK, viewModel.uiState.value.themeMode)
+        coVerify(atLeast = 1) { mockAppSettings.setThemeMode("dark") }
+    }
+
+    @Test
+    fun `init WHEN themeModeIsLight THEN uiStateReflectsLight`() = runTest {
+        // GIVEN — AppSettings returns "light" for themeMode
+        every { mockAppSettings.themeMode } returns flowOf("light")
+
+        // WHEN — ViewModel is created
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN — state reflects LIGHT mode
+        assertEquals(ThemeMode.LIGHT, viewModel.uiState.value.themeMode)
     }
 }


### PR DESCRIPTION
  Add a ThemeMode enum (SYSTEM, LIGHT, DARK) persisted to DataStore via
  AppSettings.themeMode. The Appearance settings page now shows a segmented
  button row for theme selection. CycleWiseAppUI reads the preference at
  the app root and passes the resolved darkTheme boolean to
  RhythmWiseTheme, allowing users to override the system default.

  Signed-off-by: Daniel Simmons <SmileyBob72801@gmail.com>