### PR TITLE
feat(auth): add first-time passphrase setup and onboarding flow

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassPhraseScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassPhraseScreen.kt
@@ -44,17 +44,21 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.veleda.cyclewise.R
 import com.veleda.cyclewise.ui.theme.LocalDimensions
+import kotlinx.coroutines.flow.SharedFlow
 import org.koin.androidx.compose.koinViewModel
 
 /** Alpha for the scrim overlay shown while the passphrase is being verified. */
-private const val SCRIM_ALPHA = 0.5f
+internal const val SCRIM_ALPHA = 0.5f
 
 /**
- * Passphrase unlock screen — the first screen the user sees.
+ * Passphrase screen — entry point for both first-time setup and returning unlock.
  *
- * Displays the app logo with an entrance animation, a passphrase text field with
- * visibility toggle, inline error feedback, and a collapsible water-tracking widget.
- * A semi-transparent loading overlay prevents interaction during unlock.
+ * Branches on [PassphraseUiState.isFirstTime]:
+ * - `true` → renders [SetupScreen] (onboarding pager with passphrase creation).
+ * - `false` → renders the existing unlock UI with passphrase field and Unlock button.
+ *
+ * Both paths share the same [onPassphraseEntered] callback so navigation works
+ * identically after a successful unlock.
  *
  * @param onPassphraseEntered Callback invoked when the passphrase is successfully verified
  *   and the encrypted session is ready.
@@ -63,9 +67,52 @@ private const val SCRIM_ALPHA = 0.5f
 fun PassphraseScreen(
     onPassphraseEntered: () -> Unit
 ) {
-    val dims = LocalDimensions.current
     val viewModel: PassphraseViewModel = koinViewModel()
     val uiState by viewModel.uiState.collectAsState()
+
+    // Collect one-time effects from the ViewModel (shared by both paths)
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is PassphraseEffect.NavigateToTracker -> onPassphraseEntered()
+                is PassphraseEffect.ShowError -> {
+                    // ShowError is handled within each sub-screen
+                }
+            }
+        }
+    }
+
+    // Wait for DataStore to resolve before rendering to avoid a flash
+    if (!uiState.isFirstTimeLoaded) return
+
+    if (uiState.isFirstTime) {
+        SetupScreen(
+            uiState = uiState,
+            onEvent = viewModel::onEvent,
+        )
+    } else {
+        UnlockScreen(
+            uiState = uiState,
+            onEvent = viewModel::onEvent,
+            effect = viewModel.effect,
+        )
+    }
+}
+
+/**
+ * Existing unlock UI for returning users.
+ *
+ * Displays the app logo with an entrance animation, a passphrase text field with
+ * visibility toggle, inline error feedback, and a collapsible water-tracking widget.
+ * A semi-transparent loading overlay prevents interaction during unlock.
+ */
+@Composable
+private fun UnlockScreen(
+    uiState: PassphraseUiState,
+    onEvent: (PassphraseEvent) -> Unit,
+    effect: SharedFlow<PassphraseEffect>,
+) {
+    val dims = LocalDimensions.current
 
     var passphrase by remember { mutableStateOf("") }
     var passwordVisible by remember { mutableStateOf(false) }
@@ -87,21 +134,18 @@ fun PassphraseScreen(
         focusRequester.requestFocus()
     }
 
-    // Collect one-time effects from the ViewModel
+    // Collect ShowError effects for the unlock screen
     LaunchedEffect(Unit) {
-        viewModel.effect.collect { effect ->
-            when (effect) {
-                is PassphraseEffect.NavigateToTracker -> onPassphraseEntered()
-                is PassphraseEffect.ShowError -> {
-                    errorMessage = errorString
-                }
+        effect.collect { e ->
+            if (e is PassphraseEffect.ShowError) {
+                errorMessage = errorString
             }
         }
     }
 
     val submit = {
         if (passphrase.isNotBlank() && !uiState.isUnlocking) {
-            viewModel.onEvent(PassphraseEvent.UnlockClicked(passphrase))
+            onEvent(PassphraseEvent.UnlockClicked(passphrase))
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseEvent.kt
@@ -6,6 +6,22 @@ package com.veleda.cyclewise.ui.auth
 sealed interface PassphraseEvent {
     /** The user has entered their passphrase and tapped the Unlock button. */
     data class UnlockClicked(val passphrase: String) : PassphraseEvent
+
+    /**
+     * The first-time user has created a passphrase and tapped the Create button.
+     *
+     * Semantically distinct from [UnlockClicked] — the ViewModel validates the
+     * passphrase length and confirmation match before delegating to the same
+     * unlock sequence (key derivation, database creation, session scope,
+     * symptom prepopulation, water draft sync, navigation).
+     *
+     * @property passphrase    the new passphrase entered by the user.
+     * @property confirmation  the confirmation re-entry; must match [passphrase].
+     */
+    data class SetupClicked(
+        val passphrase: String,
+        val confirmation: String,
+    ) : PassphraseEvent
 }
 
 /**

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
@@ -15,15 +15,32 @@ import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.parameter.parametersOf
 
+/** Minimum passphrase length enforced during first-time setup. */
+internal const val MIN_PASSPHRASE_LENGTH = 8
+
 /**
  * UI state for the passphrase screen.
  *
- * @property isUnlocking `true` while an unlock attempt is in progress; used by the UI
- *           to show a loading indicator and by [PassphraseViewModel.unlock] as a
- *           re-entrancy guard to ignore duplicate tap events.
+ * @property isUnlocking        `true` while an unlock attempt is in progress; used by the UI
+ *                              to show a loading indicator and by [PassphraseViewModel.unlock]
+ *                              as a re-entrancy guard to ignore duplicate tap events.
+ * @property isFirstTime        `true` when the user has never completed setup (derived from
+ *                              `AppSettings.isPrepopulated`). When `true` the UI shows the
+ *                              onboarding setup flow instead of the unlock screen.
+ * @property isFirstTimeLoaded  `true` once [isFirstTime] has been resolved from DataStore.
+ *                              The UI should not render until this is `true` to avoid a
+ *                              flash of the wrong screen.
+ * @property passphraseError    Inline error for the passphrase field during setup (e.g. too
+ *                              short). `null` means no error.
+ * @property confirmationError  Inline error for the confirmation field during setup (e.g.
+ *                              mismatch). `null` means no error.
  */
 data class PassphraseUiState(
-    val isUnlocking: Boolean = false
+    val isUnlocking: Boolean = false,
+    val isFirstTime: Boolean = false,
+    val isFirstTimeLoaded: Boolean = false,
+    val passphraseError: String? = null,
+    val confirmationError: String? = null,
 )
 
 /**
@@ -64,16 +81,59 @@ class PassphraseViewModel(
      */
     val effect: SharedFlow<PassphraseEffect> = _effect.asSharedFlow()
 
+    init {
+        viewModelScope.launch {
+            val prepopulated = appSettings.isPrepopulated.first()
+            _uiState.update {
+                it.copy(
+                    isFirstTime = !prepopulated,
+                    isFirstTimeLoaded = true,
+                )
+            }
+        }
+    }
+
     /**
      * Single entry-point for all screen-level user interactions.
      *
      * Delegates to the appropriate handler based on the [event] type.
-     * Currently supports [PassphraseEvent.UnlockClicked].
      */
     fun onEvent(event: PassphraseEvent) {
         when (event) {
             is PassphraseEvent.UnlockClicked -> unlock(event.passphrase)
+            is PassphraseEvent.SetupClicked -> handleSetup(event.passphrase, event.confirmation)
         }
+    }
+
+    /**
+     * Validates the new passphrase during first-time setup and, if valid, delegates
+     * to the standard [unlock] flow.
+     *
+     * Validation rules (checked in order):
+     * 1. Passphrase must be at least [MIN_PASSPHRASE_LENGTH] characters.
+     * 2. Passphrase and confirmation must match exactly.
+     *
+     * If validation fails, the corresponding error field in [PassphraseUiState] is set
+     * and no unlock attempt is made. If validation passes, both error fields are cleared
+     * and [unlock] is called with the validated passphrase.
+     *
+     * @param passphrase    the new passphrase entered by the user.
+     * @param confirmation  the confirmation re-entry.
+     */
+    private fun handleSetup(passphrase: String, confirmation: String) {
+        // Clear previous errors
+        _uiState.update { it.copy(passphraseError = null, confirmationError = null) }
+
+        if (passphrase.length < MIN_PASSPHRASE_LENGTH) {
+            _uiState.update { it.copy(passphraseError = "too_short") }
+            return
+        }
+        if (passphrase != confirmation) {
+            _uiState.update { it.copy(confirmationError = "mismatch") }
+            return
+        }
+
+        unlock(passphrase)
     }
 
     /**

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/SetupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/SetupScreen.kt
@@ -1,0 +1,384 @@
+package com.veleda.cyclewise.ui.auth
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.veleda.cyclewise.R
+import com.veleda.cyclewise.ui.components.MarkdownText
+import com.veleda.cyclewise.ui.theme.LocalDimensions
+import kotlinx.coroutines.launch
+
+/** Total number of pages in the onboarding pager. */
+private const val SETUP_PAGE_COUNT = 4
+
+/**
+ * First-time onboarding screen shown when [PassphraseUiState.isFirstTime] is `true`.
+ *
+ * Contains a [HorizontalPager] with 4 pages:
+ * 1. Privacy explanation ("Your Data Stays on This Device")
+ * 2. Passphrase guidance ("Choosing a Passphrase You Will Remember")
+ * 3. No-recovery warning ("No Recovery, No Exceptions")
+ * 4. Passphrase creation form with validation
+ *
+ * Navigation between pages is handled by Next/Back buttons and swipe gestures.
+ * A page indicator (dots) shows the current position.
+ *
+ * @param uiState current [PassphraseUiState] for loading overlay and validation errors.
+ * @param onEvent callback to dispatch [PassphraseEvent]s to the ViewModel.
+ */
+@Composable
+fun SetupScreen(
+    uiState: PassphraseUiState,
+    onEvent: (PassphraseEvent) -> Unit,
+) {
+    val dims = LocalDimensions.current
+    val pagerState = rememberPagerState(pageCount = { SETUP_PAGE_COUNT })
+    val coroutineScope = rememberCoroutineScope()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = dims.xl, vertical = dims.lg),
+        ) {
+            // Page indicator dots
+            PageIndicator(
+                pageCount = SETUP_PAGE_COUNT,
+                currentPage = pagerState.currentPage,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = dims.md),
+            )
+
+            // Pager content
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.weight(1f),
+            ) { page ->
+                when (page) {
+                    0 -> InfoPage(
+                        title = stringResource(R.string.setup_page1_title),
+                        body = stringResource(R.string.setup_page1_body),
+                    )
+                    1 -> InfoPage(
+                        title = stringResource(R.string.setup_page2_title),
+                        body = stringResource(R.string.setup_page2_body),
+                    )
+                    2 -> InfoPage(
+                        title = stringResource(R.string.setup_page3_title),
+                        body = stringResource(R.string.setup_page3_body),
+                    )
+                    3 -> CreatePassphrasePage(
+                        uiState = uiState,
+                        onEvent = onEvent,
+                    )
+                }
+            }
+
+            // Navigation buttons
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = dims.md),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Back button (hidden on page 1)
+                if (pagerState.currentPage > 0) {
+                    TextButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                            }
+                        },
+                        modifier = Modifier.testTag("setup-back"),
+                    ) {
+                        Text(stringResource(R.string.setup_back))
+                    }
+                } else {
+                    Spacer(Modifier.width(dims.buttonMin))
+                }
+
+                // Next button (hidden on last page — the create button is on the form)
+                if (pagerState.currentPage < SETUP_PAGE_COUNT - 1) {
+                    Button(
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                            }
+                        },
+                        modifier = Modifier.testTag("setup-next"),
+                    ) {
+                        Text(stringResource(R.string.setup_next))
+                    }
+                } else {
+                    Spacer(Modifier.width(dims.buttonMin))
+                }
+            }
+        }
+
+        // Loading overlay (same pattern as unlock screen)
+        if (uiState.isUnlocking) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.scrim.copy(alpha = SCRIM_ALPHA)),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+    }
+}
+
+/**
+ * Page indicator showing dots for each page, with the current page highlighted.
+ *
+ * @param pageCount   total number of pages.
+ * @param currentPage zero-based index of the current page.
+ * @param modifier    modifier applied to the indicator row.
+ */
+@Composable
+private fun PageIndicator(
+    pageCount: Int,
+    currentPage: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        repeat(pageCount) { index ->
+            val color by animateColorAsState(
+                targetValue = if (index == currentPage) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.outlineVariant
+                },
+                label = "page_indicator_$index",
+            )
+            Box(
+                modifier = Modifier
+                    .padding(horizontal = 4.dp)
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(color)
+            )
+        }
+    }
+}
+
+/**
+ * Educational information page used for pages 1–3 of the onboarding flow.
+ *
+ * Displays a title and body text. The body is rendered via [MarkdownText] to
+ * support `**bold**` and bullet list formatting.
+ *
+ * @param title page title displayed as a headline.
+ * @param body  Markdown-formatted body text.
+ */
+@Composable
+private fun InfoPage(
+    title: String,
+    body: String,
+) {
+    val dims = LocalDimensions.current
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = dims.md),
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(Modifier.height(dims.md))
+        MarkdownText(
+            text = body,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+/**
+ * Passphrase creation form (page 4 of the onboarding flow).
+ *
+ * Contains two password fields with visibility toggles, inline validation errors,
+ * and a "Create and Unlock" button. Validation is performed by the ViewModel via
+ * [PassphraseEvent.SetupClicked].
+ *
+ * @param uiState current state for validation errors and loading indicator.
+ * @param onEvent callback to dispatch [PassphraseEvent.SetupClicked].
+ */
+@Composable
+private fun CreatePassphrasePage(
+    uiState: PassphraseUiState,
+    onEvent: (PassphraseEvent) -> Unit,
+) {
+    val dims = LocalDimensions.current
+
+    var passphrase by remember { mutableStateOf("") }
+    var confirmation by remember { mutableStateOf("") }
+    var passphraseVisible by remember { mutableStateOf(false) }
+    var confirmVisible by remember { mutableStateOf(false) }
+
+    val passphraseErrorText = if (uiState.passphraseError != null) {
+        stringResource(R.string.setup_error_too_short)
+    } else {
+        null
+    }
+    val confirmationErrorText = if (uiState.confirmationError != null) {
+        stringResource(R.string.setup_error_mismatch)
+    } else {
+        null
+    }
+
+    val canSubmit = passphrase.length >= MIN_PASSPHRASE_LENGTH &&
+        confirmation.isNotBlank() &&
+        !uiState.isUnlocking
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = dims.md),
+    ) {
+        Text(
+            text = stringResource(R.string.setup_page4_title),
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(Modifier.height(dims.lg))
+
+        // Create passphrase field
+        OutlinedTextField(
+            value = passphrase,
+            onValueChange = { passphrase = it },
+            label = { Text(stringResource(R.string.setup_passphrase_label)) },
+            visualTransformation = if (passphraseVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            trailingIcon = {
+                TextButton(onClick = { passphraseVisible = !passphraseVisible }) {
+                    Text(
+                        text = stringResource(
+                            if (passphraseVisible) R.string.passphrase_hide
+                            else R.string.passphrase_show
+                        ),
+                        style = MaterialTheme.typography.labelMedium
+                    )
+                }
+            },
+            isError = passphraseErrorText != null,
+            supportingText = if (passphraseErrorText != null) {
+                {
+                    Text(
+                        text = passphraseErrorText,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            } else {
+                null
+            },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("setup-passphrase-input"),
+        )
+        Spacer(Modifier.height(dims.md))
+
+        // Confirm passphrase field
+        OutlinedTextField(
+            value = confirmation,
+            onValueChange = { confirmation = it },
+            label = { Text(stringResource(R.string.setup_confirm_label)) },
+            visualTransformation = if (confirmVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            trailingIcon = {
+                TextButton(onClick = { confirmVisible = !confirmVisible }) {
+                    Text(
+                        text = stringResource(
+                            if (confirmVisible) R.string.passphrase_hide
+                            else R.string.passphrase_show
+                        ),
+                        style = MaterialTheme.typography.labelMedium
+                    )
+                }
+            },
+            isError = confirmationErrorText != null,
+            supportingText = if (confirmationErrorText != null) {
+                {
+                    Text(
+                        text = confirmationErrorText,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            } else {
+                null
+            },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("setup-confirm-input"),
+        )
+        Spacer(Modifier.height(dims.lg))
+
+        // Create and Unlock button
+        Button(
+            onClick = {
+                onEvent(PassphraseEvent.SetupClicked(passphrase, confirmation))
+            },
+            enabled = canSubmit,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("setup-create-button"),
+        ) {
+            Text(stringResource(R.string.setup_create_button))
+        }
+    }
+}

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -166,6 +166,22 @@
     <string name="passphrase_logo_description">RhythmWise logo</string>
     <string name="passphrase_water_toggle">Quick log water</string>
 
+    <!-- Setup / Onboarding -->
+    <string name="setup_page1_title">Your Data Stays on This Device</string>
+    <string name="setup_page1_body">RhythmWise stores everything you track right here on your phone. Your cycle data, symptoms, moods, and notes never leave this device. There is no account, no cloud sync, and no way for anyone (including us) to see your information.\n\nTo keep your data safe, the app encrypts it with a passphrase that only you know. Think of it as a lock on a private journal. Without the right passphrase, the data is unreadable.</string>
+    <string name="setup_page2_title">Choosing a Passphrase You Will Remember</string>
+    <string name="setup_page2_body">A good passphrase is a short phrase that is easy for you to picture but hard for someone else to guess.\n\n**How to build one:**\n- Pick 4 or 5 unrelated words and string them together. \"purple dog Tuesday pancake\" is much stronger than a short password with special characters\n- Add a personal twist that helps it stick in your mind. Maybe swap a word for something only you would think of, or picture a silly scene\n- Avoid names, birthdays, and common phrases. \"ILoveYou123\" is one of the first things an attacker would try\n\n**Why this works:** Length beats complexity. A passphrase with 4 random words is far stronger than \"P@ssw0rd!\" and much easier to type on a phone.</string>
+    <string name="setup_page3_title">No Recovery, No Exceptions</string>
+    <string name="setup_page3_body">If you forget your passphrase, your data cannot be recovered. There is no reset button, no recovery email, and no back door. This is intentional.\n\nThe same encryption that keeps your data private means that nobody, not even this app, can unlock it without the correct passphrase.\n\n**Before you continue:**\n- Make sure you have a passphrase you are confident you will remember\n- Consider writing it down and keeping it somewhere safe and private until you have it memorized\n- Once you have it memorized, destroy the written copy</string>
+    <string name="setup_page4_title">Create Your Passphrase</string>
+    <string name="setup_passphrase_label">Create passphrase</string>
+    <string name="setup_confirm_label">Confirm passphrase</string>
+    <string name="setup_create_button">Create and Unlock</string>
+    <string name="setup_error_too_short">Passphrase must be at least 8 characters</string>
+    <string name="setup_error_mismatch">Passphrases do not match</string>
+    <string name="setup_next">Next</string>
+    <string name="setup_back">Back</string>
+
     <!-- Insights -->
     <string name="insights_title">Insights</string>
     <string name="insights_empty">Not enough data to generate insights yet. Keep tracking!</string>

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModelTest.kt
@@ -1,0 +1,174 @@
+package com.veleda.cyclewise.ui.auth
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import android.util.Log
+import com.veleda.cyclewise.androidData.local.draft.LockedWaterDraft
+import com.veleda.cyclewise.settings.AppSettings
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [PassphraseViewModel] following the Given-When-Then convention.
+ *
+ * Tests cover first-time detection via `AppSettings.isPrepopulated`,
+ * passphrase validation during setup, and the setup-to-unlock delegation.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PassphraseViewModelTest {
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var mockAppSettings: AppSettings
+    private lateinit var mockLockedWaterDraft: LockedWaterDraft
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockAppSettings = mockk(relaxed = true)
+        mockLockedWaterDraft = mockk(relaxed = true)
+
+        // Mock android.util.Log which throws RuntimeException("Stub!") in
+        // plain JUnit tests. The unlock() catch block calls Log.e().
+        mockkStatic(Log::class)
+        every { Log.e(any(), any()) } returns 0
+
+        // Start Koin with an empty module so getKoin() does not crash
+        // when the unlock flow is reached during validation tests.
+        startKoin { modules(module { }) }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        stopKoin()
+    }
+
+    private fun createViewModel(): PassphraseViewModel {
+        return PassphraseViewModel(
+            appSettings = mockAppSettings,
+            lockedWaterDraft = mockLockedWaterDraft,
+        )
+    }
+
+    // ── First-time detection ──────────────────────────────────────────
+
+    @Test
+    fun `init WHEN isPrepopulated is false THEN isFirstTime is true`() = runTest {
+        // GIVEN — isPrepopulated returns false (first-time user)
+        every { mockAppSettings.isPrepopulated } returns flowOf(false)
+
+        // WHEN — ViewModel is created
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN — isFirstTime is true and isFirstTimeLoaded is true
+        val state = viewModel.uiState.value
+        assertTrue(state.isFirstTime)
+        assertTrue(state.isFirstTimeLoaded)
+    }
+
+    @Test
+    fun `init WHEN isPrepopulated is true THEN isFirstTime is false`() = runTest {
+        // GIVEN — isPrepopulated returns true (returning user)
+        every { mockAppSettings.isPrepopulated } returns flowOf(true)
+
+        // WHEN — ViewModel is created
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // THEN — isFirstTime is false and isFirstTimeLoaded is true
+        val state = viewModel.uiState.value
+        assertFalse(state.isFirstTime)
+        assertTrue(state.isFirstTimeLoaded)
+    }
+
+    // ── Setup validation ──────────────────────────────────────────────
+
+    @Test
+    fun `onEvent SetupClicked WHEN passphrase below 8 characters THEN passphraseError emitted`() = runTest {
+        // GIVEN — ViewModel initialized for first-time user
+        every { mockAppSettings.isPrepopulated } returns flowOf(false)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — SetupClicked with a short passphrase
+        viewModel.onEvent(PassphraseEvent.SetupClicked("short", "short"))
+        advanceUntilIdle()
+
+        // THEN — passphraseError is set, confirmationError is null, no unlock attempted
+        val state = viewModel.uiState.value
+        assertEquals("too_short", state.passphraseError)
+        assertNull(state.confirmationError)
+        assertFalse(state.isUnlocking)
+    }
+
+    @Test
+    fun `onEvent SetupClicked WHEN confirmation does not match THEN confirmationError emitted`() = runTest {
+        // GIVEN — ViewModel initialized for first-time user
+        every { mockAppSettings.isPrepopulated } returns flowOf(false)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — SetupClicked with mismatched confirmation
+        viewModel.onEvent(
+            PassphraseEvent.SetupClicked("validpassphrase", "differentphrase")
+        )
+        advanceUntilIdle()
+
+        // THEN — confirmationError is set, passphraseError is null, no unlock attempted
+        val state = viewModel.uiState.value
+        assertNull(state.passphraseError)
+        assertEquals("mismatch", state.confirmationError)
+        assertFalse(state.isUnlocking)
+    }
+
+    @Test
+    fun `onEvent SetupClicked WHEN valid matching passphrase THEN validation passes and unlock attempted`() = runTest {
+        // GIVEN — ViewModel initialized for first-time user
+        every { mockAppSettings.isPrepopulated } returns flowOf(false)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — SetupClicked with valid, matching passphrase
+        // handleSetup() validates and calls unlock() if valid. The unlock
+        // itself will fail (no real session scope) but we are verifying that
+        // validation passed — i.e. neither error field was set.
+        viewModel.onEvent(
+            PassphraseEvent.SetupClicked("validpassphrase", "validpassphrase")
+        )
+
+        // Wait for any IO-dispatched work inside unlock() to settle.
+        @Suppress("BlockingMethodInNonBlockingContext")
+        Thread.sleep(500)
+        advanceUntilIdle()
+
+        // THEN — validation errors are both null, confirming handleSetup
+        // did NOT return early and the unlock flow was reached.
+        val state = viewModel.uiState.value
+        assertNull(state.passphraseError)
+        assertNull(state.confirmationError)
+    }
+}


### PR DESCRIPTION
  Introduce a 4-page onboarding HorizontalPager shown on first launch
  (when isPrepopulated is false) that educates users about the privacy
  model, passphrase selection, and the no-recovery policy before they
  create their passphrase. Returning users see the existing unlock
  screen unchanged.

  - Add isFirstTime and validation fields to PassphraseUiState
  - Add SetupClicked event with min-length and confirmation matching
  - Branch PassPhraseScreen on isFirstTime (SetupScreen vs UnlockScreen)
  - Create SetupScreen with 4-page pager, page indicators, and nav
  - Add 14 string resources for onboarding copy
  - Add 5 unit tests for ViewModel first-time detection and validation

  Signed-off-by: Daniel Simmons <SmileyBob72801@gmail.com>