### PR TITLE
feat(ui): show confirmation dialog when removing period days with log…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(awk:*)",
+      "Bash(ls:*)",
+      "Bash(./gradlew:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(gh issue list:*)",
+      "WebFetch(domain:m3.material.io)",
+      "Bash(git status:*)",
+      "Bash(test:*)",
+      "Bash(cd:*)",
+      "WebSearch",
+      "WebFetch(domain:medium.com)",
+      "WebFetch(domain:docs.claude.com)",
+      "WebFetch(domain:support.google.com)",
+      "WebFetch(domain:detekt.dev)",
+      "WebFetch(domain:plugins.gradle.org)",
+      "WebFetch(domain:github.com)",
+      "Bash(\"/c/Program Files/Android/Android Studio/jbr/bin/javap.exe\":*)",
+      "WebFetch(domain:guide.vico.patrykandpatrick.com)",
+      "WebFetch(domain:docs.github.com)",
+      "Bash(xargs wc:*)"
+    ]
+  }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/PeriodLogDao.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/dao/PeriodLogDao.kt
@@ -28,6 +28,10 @@ interface PeriodLogDao {
     @Query("DELETE FROM period_logs WHERE entry_id = :dailyEntryId")
     suspend fun deleteLogForEntry(dailyEntryId: String)
 
+    /** Returns period logs for multiple daily entries in a single query, avoiding N+1. */
+    @Query("SELECT * FROM period_logs WHERE entry_id IN (:dailyEntryIds)")
+    suspend fun getLogsForEntries(dailyEntryIds: List<String>): List<PeriodLogEntity>
+
     @Query("SELECT * FROM period_logs")
     fun getAllPeriodLogs(): Flow<List<PeriodLogEntity>>
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomPeriodRepository.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/repository/RoomPeriodRepository.kt
@@ -511,6 +511,21 @@ class RoomPeriodRepository(
         }
     }
 
+    /** @see PeriodRepository.getPeriodLogForDate */
+    override suspend fun getPeriodLogForDate(date: LocalDate): PeriodLog? {
+        val entryEntity = dailyEntryDao.getEntryForDate(date).firstOrNull() ?: return null
+        return periodLogDao.getLogForEntry(entryEntity.id).firstOrNull()?.toDomain()
+    }
+
+    /** @see PeriodRepository.getPeriodLogsForDateRange */
+    override suspend fun getPeriodLogsForDateRange(startDate: LocalDate, endDate: LocalDate): List<PeriodLog> {
+        val entryEntities = dailyEntryDao.getEntriesForDateRange(startDate, endDate).firstOrNull()
+            ?: return emptyList()
+        if (entryEntities.isEmpty()) return emptyList()
+        val entryIds = entryEntities.map { it.id }
+        return periodLogDao.getLogsForEntries(entryIds).map { it.toDomain() }
+    }
+
     /**
      * **[DEBUG ONLY]** Clears all user data and seeds the database with 6 completed
      * periods spanning several months, each with daily entries, symptoms, and medications.

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogEvent.kt
@@ -74,6 +74,12 @@ sealed interface DailyLogEvent {
      */
     data class PeriodToggled(val isOnPeriod: Boolean) : DailyLogEvent
 
+    /** The user confirmed unmarking a period day that had logged data. */
+    data object UnmarkPeriodConfirmed : DailyLogEvent
+
+    /** The user dismissed the unmark-period confirmation dialog. */
+    data object UnmarkPeriodDismissed : DailyLogEvent
+
     /** The user tapped the increment button on the water counter. */
     data object WaterIncrement : DailyLogEvent
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
@@ -497,6 +497,12 @@ fun DailyLogScreen(
                 }
                 }
 
+                UnmarkPeriodDayDialog(
+                    showDialog = uiState.showUnmarkPeriodConfirmation,
+                    onConfirm = { viewModel.onEvent(DailyLogEvent.UnmarkPeriodConfirmed) },
+                    onDismiss = { viewModel.onEvent(DailyLogEvent.UnmarkPeriodDismissed) },
+                )
+
                 SnackbarHost(
                     hostState = snackbarHostState,
                     modifier = Modifier.align(Alignment.BottomCenter),

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModel.kt
@@ -76,6 +76,7 @@ data class DailyLogUiState(
     val medicationToDelete: Medication? = null,
     val medicationDeleteLogCount: Int = 0,
     val renameError: String? = null,
+    val showUnmarkPeriodConfirmation: Boolean = false,
 )
 
 /**
@@ -257,13 +258,30 @@ class DailyLogViewModel(
             }
 
             is DailyLogEvent.PeriodToggled -> {
-                viewModelScope.launch {
-                    if (event.isOnPeriod) {
+                if (event.isOnPeriod) {
+                    viewModelScope.launch {
                         periodRepository.logPeriodDay(entryDate)
-                    } else {
-                        periodRepository.unLogPeriodDay(entryDate)
+                        _uiState.update { it.copy(isPeriodDay = true) }
                     }
-                    _uiState.update { it.copy(isPeriodDay = event.isOnPeriod) }
+                    autoSave()
+                } else {
+                    // If the period log has data, show confirmation instead of proceeding
+                    val hasData = _uiState.value.log?.periodLog?.hasData() == true
+                    if (!hasData) {
+                        viewModelScope.launch {
+                            periodRepository.unLogPeriodDay(entryDate)
+                            _uiState.update { it.copy(isPeriodDay = false) }
+                        }
+                        autoSave()
+                    }
+                    // If hasData, the reduce function already set showUnmarkPeriodConfirmation = true
+                }
+            }
+
+            is DailyLogEvent.UnmarkPeriodConfirmed -> {
+                viewModelScope.launch {
+                    periodRepository.unLogPeriodDay(entryDate)
+                    _uiState.update { it.copy(isPeriodDay = false) }
                 }
                 autoSave()
             }
@@ -420,6 +438,7 @@ class DailyLogViewModel(
             }
 
             // No side effects for state-only events.
+            is DailyLogEvent.UnmarkPeriodDismissed,
             is DailyLogEvent.LogLoaded,
             is DailyLogEvent.LibraryUpdated,
             is DailyLogEvent.SymptomNameChanged,
@@ -546,8 +565,21 @@ class DailyLogViewModel(
                     )
                     currentState.copy(log = log.copy(periodLog = newPeriodLog))
                 } else {
-                    currentState.copy(log = log.copy(periodLog = null))
+                    if (log.periodLog?.hasData() == true) {
+                        currentState.copy(showUnmarkPeriodConfirmation = true)
+                    } else {
+                        currentState.copy(log = log.copy(periodLog = null))
+                    }
                 }
+            }
+            is DailyLogEvent.UnmarkPeriodConfirmed -> {
+                currentState.copy(
+                    log = log.copy(periodLog = null),
+                    showUnmarkPeriodConfirmation = false,
+                )
+            }
+            is DailyLogEvent.UnmarkPeriodDismissed -> {
+                currentState.copy(showUnmarkPeriodConfirmation = false)
             }
             is DailyLogEvent.WaterIncrement -> {
                 currentState.copy(waterCups = currentState.waterCups + 1)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/UnmarkPeriodDayDialog.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/UnmarkPeriodDayDialog.kt
@@ -1,0 +1,49 @@
+package com.veleda.cyclewise.ui.log
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.veleda.cyclewise.R
+
+/**
+ * Confirmation dialog shown in the DailyLog screen when the user toggles the period
+ * switch off on a day that has logged flow, color, or consistency data.
+ *
+ * @param showDialog Whether the dialog is visible.
+ * @param onConfirm Called when the user confirms removal.
+ * @param onDismiss Called when the user cancels or dismisses the dialog.
+ */
+@Composable
+internal fun UnmarkPeriodDayDialog(
+    showDialog: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (showDialog) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text(stringResource(R.string.unmark_period_day_title)) },
+            text = { Text(stringResource(R.string.unmark_period_day_message)) },
+            confirmButton = {
+                Button(
+                    onClick = onConfirm,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text(stringResource(R.string.unmark_period_day_confirm))
+                }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.tracker_cancel))
+                }
+            },
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerEvent.kt
@@ -36,6 +36,17 @@ sealed interface TrackerEvent {
     /** Dispatched when the screen is first composed, triggering auto-close period logic. */
     data object ScreenEntered : TrackerEvent
 
+    // ── Unmark Period Confirmation ────────────────────────────────────
+
+    /** The user confirmed unmarking a single period day that had data. */
+    data class UnmarkPeriodDayConfirmed(val date: LocalDate) : TrackerEvent
+
+    /** The user confirmed unmarking multiple period days (drag-shrink) that had data. */
+    data class UnmarkPeriodRangeConfirmed(val dates: List<LocalDate>) : TrackerEvent
+
+    /** The user dismissed the unmark-period confirmation dialog. */
+    data object UnmarkPeriodDismissed : TrackerEvent
+
     // ── Educational ──────────────────────────────────────────────────
 
     /** The user tapped an info button to view educational content for the given [contentTag]. */

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerScreen.kt
@@ -269,6 +269,16 @@ fun TrackerScreen(navController: NavController) {
         onEvent = viewModel::onEvent,
     )
 
+    UnmarkPeriodDayConfirmationDialog(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+    )
+
+    UnmarkPeriodRangeConfirmationDialog(
+        uiState = uiState,
+        onEvent = viewModel::onEvent,
+    )
+
     uiState.educationalArticles?.let { articles ->
         EducationalBottomSheet(
             articles = articles,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerViewModel.kt
@@ -67,6 +67,10 @@ data class TrackerUiState(
     val periodIdToDelete: String? = null,
     val waterCupsForSheet: Int? = null,
     val educationalArticles: List<EducationalArticle>? = null,
+    val showUnmarkConfirmation: Boolean = false,
+    val unmarkDate: LocalDate? = null,
+    val unmarkDates: List<LocalDate> = emptyList(),
+    val unmarkDaysWithDataCount: Int = 0,
     val selectedHeatmapMetric: HeatmapMetric? = null,
     val heatmapIntensities: Map<LocalDate, Float> = emptyMap(),
 ) {
@@ -199,11 +203,25 @@ class TrackerViewModel(
                     event.date in (it.startDate..(it.endDate ?: Clock.System.todayIn(TimeZone.currentSystemDefault())))
                 }
                 if (periodForDate != null) {
-                    periodRepository.unLogPeriodDay(event.date)
+                    // Check if the period log has user-entered data before unmarking
+                    val periodLog = periodRepository.getPeriodLogForDate(event.date)
+                    if (periodLog?.hasData() == true) {
+                        _uiState.update {
+                            it.copy(
+                                showUnmarkConfirmation = true,
+                                unmarkDate = event.date,
+                                unmarkDates = emptyList(),
+                                unmarkDaysWithDataCount = 1,
+                            )
+                        }
+                    } else {
+                        periodRepository.unLogPeriodDay(event.date)
+                        _effect.tryEmit(TrackerEffect.PeriodMarked)
+                    }
                 } else {
                     periodRepository.logPeriodDay(event.date)
+                    _effect.tryEmit(TrackerEffect.PeriodMarked)
                 }
-                _effect.tryEmit(TrackerEffect.PeriodMarked)
             }
 
             is TrackerEvent.PeriodRangeDragged -> viewModelScope.launch {
@@ -224,11 +242,11 @@ class TrackerViewModel(
                         && anchor != (anchorPeriod.endDate ?: today)
                         && release > anchor
                         && release <= (anchorPeriod.endDate ?: today) -> {
-                        var d = anchor
-                        while (d < release) {
-                            periodRepository.unLogPeriodDay(d)
-                            d = d.plus(1, DateTimeUnit.DAY)
+                        val datesToRemove = buildList {
+                            var d = anchor
+                            while (d < release) { add(d); d = d.plus(1, DateTimeUnit.DAY) }
                         }
+                        handleShrinkWithDataCheck(datesToRemove)
                     }
                     // Shrink from end: anchor is end of period, release is earlier (inside period).
                     anchorPeriod != null
@@ -236,11 +254,11 @@ class TrackerViewModel(
                         && anchor != anchorPeriod.startDate
                         && release < anchor
                         && release >= anchorPeriod.startDate -> {
-                        var d = anchor
-                        while (d > release) {
-                            periodRepository.unLogPeriodDay(d)
-                            d = d.minus(1, DateTimeUnit.DAY)
+                        val datesToRemove = buildList {
+                            var d = anchor
+                            while (d > release) { add(d); d = d.minus(1, DateTimeUnit.DAY) }
                         }
+                        handleShrinkWithDataCheck(datesToRemove)
                     }
                     // Default: mark all days in range as period days.
                     else -> {
@@ -249,9 +267,9 @@ class TrackerViewModel(
                             periodRepository.logPeriodDay(d)
                             d = d.plus(1, DateTimeUnit.DAY)
                         }
+                        _effect.tryEmit(TrackerEffect.PeriodMarked)
                     }
                 }
-                _effect.tryEmit(TrackerEffect.PeriodMarked)
             }
 
             is TrackerEvent.EditLogClicked -> viewModelScope.launch {
@@ -275,10 +293,23 @@ class TrackerViewModel(
                 }
             }
 
+            is TrackerEvent.UnmarkPeriodDayConfirmed -> viewModelScope.launch {
+                periodRepository.unLogPeriodDay(event.date)
+                _effect.tryEmit(TrackerEffect.PeriodMarked)
+            }
+
+            is TrackerEvent.UnmarkPeriodRangeConfirmed -> viewModelScope.launch {
+                for (date in event.dates) {
+                    periodRepository.unLogPeriodDay(date)
+                }
+                _effect.tryEmit(TrackerEffect.PeriodMarked)
+            }
+
             // State-only events — no side effects needed.
             is TrackerEvent.DismissLogSheet,
             is TrackerEvent.DeletePeriodRequested,
             is TrackerEvent.DeletePeriodDismissed,
+            is TrackerEvent.UnmarkPeriodDismissed,
             is TrackerEvent.DismissEducationalSheet -> { /* state-only */ }
         }
     }
@@ -321,12 +352,58 @@ class TrackerViewModel(
                     periodIdToDelete = null
                 )
             }
+            is TrackerEvent.UnmarkPeriodDayConfirmed -> currentState.copy(
+                showUnmarkConfirmation = false,
+                unmarkDate = null,
+                unmarkDates = emptyList(),
+                unmarkDaysWithDataCount = 0,
+            )
+            is TrackerEvent.UnmarkPeriodRangeConfirmed -> currentState.copy(
+                showUnmarkConfirmation = false,
+                unmarkDate = null,
+                unmarkDates = emptyList(),
+                unmarkDaysWithDataCount = 0,
+            )
+            is TrackerEvent.UnmarkPeriodDismissed -> currentState.copy(
+                showUnmarkConfirmation = false,
+                unmarkDate = null,
+                unmarkDates = emptyList(),
+                unmarkDaysWithDataCount = 0,
+            )
             is TrackerEvent.SelectHeatmapMetric -> currentState.copy(
                 selectedHeatmapMetric = event.metric,
                 heatmapIntensities = if (event.metric == null) emptyMap() else currentState.heatmapIntensities,
             )
             is TrackerEvent.ShowEducationalSheet -> currentState
             is TrackerEvent.DismissEducationalSheet -> currentState.copy(educationalArticles = null)
+        }
+    }
+
+    /**
+     * Checks whether any of the [datesToRemove] have period logs with user-entered data.
+     * If so, shows the multi-day confirmation dialog; otherwise proceeds with silent removal.
+     */
+    private suspend fun handleShrinkWithDataCheck(datesToRemove: List<LocalDate>) {
+        if (datesToRemove.isEmpty()) return
+        val rangeStart = datesToRemove.min()
+        val rangeEnd = datesToRemove.max()
+        val periodLogs = periodRepository.getPeriodLogsForDateRange(rangeStart, rangeEnd)
+        val daysWithData = periodLogs.count { it.hasData() }
+
+        if (daysWithData > 0) {
+            _uiState.update {
+                it.copy(
+                    showUnmarkConfirmation = true,
+                    unmarkDate = null,
+                    unmarkDates = datesToRemove,
+                    unmarkDaysWithDataCount = daysWithData,
+                )
+            }
+        } else {
+            for (date in datesToRemove) {
+                periodRepository.unLogPeriodDay(date)
+            }
+            _effect.tryEmit(TrackerEffect.PeriodMarked)
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/UnmarkPeriodConfirmationDialog.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/UnmarkPeriodConfirmationDialog.kt
@@ -1,0 +1,87 @@
+package com.veleda.cyclewise.ui.tracker
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.veleda.cyclewise.R
+
+/**
+ * Confirmation dialog shown when the user long-presses a single period day that has
+ * logged flow, color, or consistency data. Warns that the data will be permanently
+ * deleted if the day is unmarked.
+ */
+@Composable
+internal fun UnmarkPeriodDayConfirmationDialog(
+    uiState: TrackerUiState,
+    onEvent: (TrackerEvent) -> Unit,
+) {
+    if (uiState.showUnmarkConfirmation && uiState.unmarkDate != null) {
+        AlertDialog(
+            onDismissRequest = { onEvent(TrackerEvent.UnmarkPeriodDismissed) },
+            title = { Text(stringResource(R.string.unmark_period_day_title)) },
+            text = { Text(stringResource(R.string.unmark_period_day_message)) },
+            confirmButton = {
+                Button(
+                    onClick = { onEvent(TrackerEvent.UnmarkPeriodDayConfirmed(uiState.unmarkDate)) },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text(stringResource(R.string.unmark_period_day_confirm))
+                }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = { onEvent(TrackerEvent.UnmarkPeriodDismissed) }) {
+                    Text(stringResource(R.string.tracker_cancel))
+                }
+            },
+        )
+    }
+}
+
+/**
+ * Confirmation dialog shown when a drag-shrink operation would remove multiple period
+ * days, some of which have logged flow, color, or consistency data. Displays the total
+ * number of days being removed and how many contain data.
+ */
+@Composable
+internal fun UnmarkPeriodRangeConfirmationDialog(
+    uiState: TrackerUiState,
+    onEvent: (TrackerEvent) -> Unit,
+) {
+    if (uiState.showUnmarkConfirmation && uiState.unmarkDates.isNotEmpty()) {
+        AlertDialog(
+            onDismissRequest = { onEvent(TrackerEvent.UnmarkPeriodDismissed) },
+            title = { Text(stringResource(R.string.unmark_period_range_title)) },
+            text = {
+                Text(
+                    stringResource(
+                        R.string.unmark_period_range_message,
+                        uiState.unmarkDates.size,
+                        uiState.unmarkDaysWithDataCount,
+                    )
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = { onEvent(TrackerEvent.UnmarkPeriodRangeConfirmed(uiState.unmarkDates)) },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text(stringResource(R.string.unmark_period_range_confirm, uiState.unmarkDates.size))
+                }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = { onEvent(TrackerEvent.UnmarkPeriodDismissed) }) {
+                    Text(stringResource(R.string.tracker_cancel))
+                }
+            },
+        )
+    }
+}

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -73,6 +73,12 @@
     <string name="tracker_delete_message">Are you sure you want to permanently delete this period and all its associated flow logs? This action cannot be undone.</string>
     <string name="tracker_delete_confirm">Delete Period</string>
     <string name="tracker_cancel">Cancel</string>
+    <string name="unmark_period_day_title">Remove Period Day?</string>
+    <string name="unmark_period_day_message">This day has logged flow, color, or consistency data. Removing it as a period day will permanently delete that data.\n\nYour other daily log entries (mood, symptoms, medications, notes) will not be affected.</string>
+    <string name="unmark_period_day_confirm">Remove</string>
+    <string name="unmark_period_range_title">Remove Period Days?</string>
+    <string name="unmark_period_range_message">Remove %1$d period days? %2$d of them have logged flow, color, or consistency data that will be permanently deleted.\n\nYour other daily log entries will not be affected.</string>
+    <string name="unmark_period_range_confirm">Remove %1$d Days</string>
     <string name="tracker_ongoing_period">Ongoing Period: %s</string>
     <string name="tracker_instructions">Long press a day to start/mark your period. Tap to log details.</string>
     <string name="tracker_instructions_drag">Long press a day to toggle period. Press and drag to select a range.</string>

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/testutil/TestDomainBuilders.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/testutil/TestDomainBuilders.kt
@@ -35,7 +35,7 @@ fun buildDailyEntry(
 fun buildPeriodLog(
     id: String = uuid4().toString(),
     entryId: String = "entry-1",
-    flowIntensity: FlowIntensity = FlowIntensity.MEDIUM,
+    flowIntensity: FlowIntensity? = FlowIntensity.MEDIUM,
     periodColor: PeriodColor? = null,
     periodConsistency: PeriodConsistency? = null,
     createdAt: Instant = TestData.INSTANT,

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModelTest.kt
@@ -22,6 +22,7 @@ import com.veleda.cyclewise.domain.usecases.RenameSymptomUseCase
 import com.veleda.cyclewise.testutil.TestData
 import com.veleda.cyclewise.testutil.buildMedication
 import com.veleda.cyclewise.testutil.buildMedicationLog
+import com.veleda.cyclewise.testutil.buildPeriodLog
 import com.veleda.cyclewise.testutil.buildSymptom
 import com.veleda.cyclewise.testutil.buildSymptomLog
 import android.util.Log
@@ -665,5 +666,149 @@ class DailyLogViewModelTest {
         coVerify(exactly = 1) { mockDeleteMedicationUseCase("m1") }
         assertNull(vm.uiState.value.medicationToDelete)
         assertEquals(0, vm.uiState.value.log!!.medicationLogs.size, "deleted medication logs should be filtered out")
+    }
+
+    // ── Unmark Period Confirmation tests ─────────────────────────────
+
+    @Test
+    fun `onEvent PeriodToggled WHEN falseAndPeriodLogHasData THEN showsConfirmationAndDoesNotUnlog`() = runTest {
+        // GIVEN — ViewModel with a period that has flow data
+        val periodLogWithData = buildPeriodLog(
+            entryId = "entry-1",
+            flowIntensity = FlowIntensity.HEAVY,
+        )
+        val logWithPeriod = testLog.copy(periodLog = periodLogWithData)
+        coEvery { mockGetOrCreateDailyLog(any()) } returns logWithPeriod
+
+        val period = Period(
+            id = "period-1",
+            startDate = testDate.minus(2, DateTimeUnit.DAY),
+            endDate = testDate.plus(2, DateTimeUnit.DAY),
+            createdAt = testInstant,
+            updatedAt = testInstant,
+        )
+        every { mockRepository.getAllPeriods() } returns flowOf(listOf(period))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.isPeriodDay)
+        assertNotNull(vm.uiState.value.log!!.periodLog)
+
+        // WHEN — user toggles period OFF
+        vm.onEvent(DailyLogEvent.PeriodToggled(isOnPeriod = false))
+        advanceUntilIdle()
+
+        // THEN — confirmation is shown, unLogPeriodDay is NOT called
+        assertTrue(vm.uiState.value.showUnmarkPeriodConfirmation, "should show confirmation dialog")
+        assertNotNull(vm.uiState.value.log!!.periodLog, "periodLog should still be intact")
+        coVerify(exactly = 0) { mockRepository.unLogPeriodDay(any()) }
+    }
+
+    @Test
+    fun `onEvent PeriodToggled WHEN falseAndPeriodLogHasNoData THEN proceedsSilently`() = runTest {
+        // GIVEN — ViewModel with a period log that has no data (null flow, color, consistency)
+        val periodLogNoData = buildPeriodLog(
+            entryId = "entry-1",
+            flowIntensity = null,
+            periodColor = null,
+            periodConsistency = null,
+        )
+        val logWithEmptyPeriod = testLog.copy(periodLog = periodLogNoData)
+        coEvery { mockGetOrCreateDailyLog(any()) } returns logWithEmptyPeriod
+
+        val period = Period(
+            id = "period-1",
+            startDate = testDate.minus(2, DateTimeUnit.DAY),
+            endDate = testDate.plus(2, DateTimeUnit.DAY),
+            createdAt = testInstant,
+            updatedAt = testInstant,
+        )
+        every { mockRepository.getAllPeriods() } returns flowOf(listOf(period))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — user toggles period OFF
+        vm.onEvent(DailyLogEvent.PeriodToggled(isOnPeriod = false))
+        advanceUntilIdle()
+
+        // THEN — proceeds silently, no confirmation dialog
+        assertFalse(vm.uiState.value.showUnmarkPeriodConfirmation, "should not show confirmation")
+        assertNull(vm.uiState.value.log!!.periodLog, "periodLog should be removed")
+        coVerify(atLeast = 1) { mockRepository.unLogPeriodDay(testDate) }
+    }
+
+    @Test
+    fun `onEvent UnmarkPeriodConfirmed THEN callsUnLogAndUpdatesState`() = runTest {
+        // GIVEN — ViewModel with a period log that has data, confirmation is showing
+        val periodLogWithData = buildPeriodLog(
+            entryId = "entry-1",
+            flowIntensity = FlowIntensity.MEDIUM,
+        )
+        val logWithPeriod = testLog.copy(periodLog = periodLogWithData)
+        coEvery { mockGetOrCreateDailyLog(any()) } returns logWithPeriod
+
+        val period = Period(
+            id = "period-1",
+            startDate = testDate.minus(2, DateTimeUnit.DAY),
+            endDate = testDate.plus(2, DateTimeUnit.DAY),
+            createdAt = testInstant,
+            updatedAt = testInstant,
+        )
+        every { mockRepository.getAllPeriods() } returns flowOf(listOf(period))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // Show the confirmation dialog
+        vm.onEvent(DailyLogEvent.PeriodToggled(isOnPeriod = false))
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.showUnmarkPeriodConfirmation)
+
+        // WHEN — user confirms
+        vm.onEvent(DailyLogEvent.UnmarkPeriodConfirmed)
+        advanceUntilIdle()
+
+        // THEN — unLogPeriodDay is called, state is updated
+        coVerify(atLeast = 1) { mockRepository.unLogPeriodDay(testDate) }
+        assertFalse(vm.uiState.value.showUnmarkPeriodConfirmation)
+        assertNull(vm.uiState.value.log!!.periodLog, "periodLog should be null after confirmation")
+        assertFalse(vm.uiState.value.isPeriodDay)
+    }
+
+    @Test
+    fun `onEvent UnmarkPeriodDismissed THEN resetsDialogState`() = runTest {
+        // GIVEN — ViewModel with confirmation dialog showing
+        val periodLogWithData = buildPeriodLog(
+            entryId = "entry-1",
+            flowIntensity = FlowIntensity.LIGHT,
+        )
+        val logWithPeriod = testLog.copy(periodLog = periodLogWithData)
+        coEvery { mockGetOrCreateDailyLog(any()) } returns logWithPeriod
+
+        val period = Period(
+            id = "period-1",
+            startDate = testDate.minus(2, DateTimeUnit.DAY),
+            endDate = testDate.plus(2, DateTimeUnit.DAY),
+            createdAt = testInstant,
+            updatedAt = testInstant,
+        )
+        every { mockRepository.getAllPeriods() } returns flowOf(listOf(period))
+
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onEvent(DailyLogEvent.PeriodToggled(isOnPeriod = false))
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.showUnmarkPeriodConfirmation)
+
+        // WHEN — user dismisses
+        vm.onEvent(DailyLogEvent.UnmarkPeriodDismissed)
+        advanceUntilIdle()
+
+        // THEN — dialog state is reset, period log is preserved
+        assertFalse(vm.uiState.value.showUnmarkPeriodConfirmation)
+        assertNotNull(vm.uiState.value.log!!.periodLog, "periodLog should be preserved after dismissal")
+        coVerify(exactly = 0) { mockRepository.unLogPeriodDay(any()) }
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/UnmarkPeriodDayDialogTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/UnmarkPeriodDayDialogTest.kt
@@ -1,0 +1,89 @@
+package com.veleda.cyclewise.ui.log
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.veleda.cyclewise.RobolectricTestApp
+import com.veleda.cyclewise.ui.theme.Dimensions
+import com.veleda.cyclewise.ui.theme.LocalDimensions
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-based Compose UI tests for [UnmarkPeriodDayDialog].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricTestApp::class)
+class UnmarkPeriodDayDialogTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun setContent(
+        showDialog: Boolean = false,
+        onConfirm: () -> Unit = {},
+        onDismiss: () -> Unit = {},
+    ) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    UnmarkPeriodDayDialog(
+                        showDialog = showDialog,
+                        onConfirm = onConfirm,
+                        onDismiss = onDismiss,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun dialog_WHEN_showDialogFalse_THEN_notDisplayed() {
+        // Given / When
+        setContent(showDialog = false)
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Day?").assertDoesNotExist()
+    }
+
+    @Test
+    fun dialog_WHEN_showDialogTrue_THEN_displayed() {
+        // Given / When
+        setContent(showDialog = true)
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Day?").assertIsDisplayed()
+    }
+
+    @Test
+    fun confirmButton_WHEN_tapped_THEN_callsOnConfirm() {
+        // Given
+        var confirmed = false
+        setContent(showDialog = true, onConfirm = { confirmed = true })
+
+        // When
+        composeTestRule.onNodeWithText("Remove").performClick()
+
+        // Then
+        assert(confirmed) { "onConfirm should have been called" }
+    }
+
+    @Test
+    fun cancelButton_WHEN_tapped_THEN_callsOnDismiss() {
+        // Given
+        var dismissed = false
+        setContent(showDialog = true, onDismiss = { dismissed = true })
+
+        // When
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        // Then
+        assert(dismissed) { "onDismiss should have been called" }
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/tracker/CycleViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/tracker/CycleViewModelTest.kt
@@ -12,6 +12,7 @@ import com.veleda.cyclewise.domain.repository.PeriodRepository
 import com.veleda.cyclewise.domain.usecases.AutoCloseOngoingPeriodUseCase
 import com.veleda.cyclewise.settings.AppSettings
 import com.veleda.cyclewise.testutil.TestData
+import com.veleda.cyclewise.testutil.buildPeriodLog
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -442,5 +443,185 @@ class CycleViewModelTest {
 
         // THEN
         assertNull(viewModel.uiState.value.educationalArticles)
+    }
+
+    // --- Unmark period confirmation tests ---
+
+    @Test
+    fun onEvent_PeriodMarkDay_WHEN_dayHasData_THEN_showsConfirmationAndDoesNotUnlog() = runTest {
+        // GIVEN — a period exists covering the date, and the period log has data
+        val period = Period("p1", today.minus(2, DateTimeUnit.DAY), today.plus(2, DateTimeUnit.DAY), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        val periodLog = buildPeriodLog(flowIntensity = FlowIntensity.HEAVY)
+        coEvery { mockRepository.getPeriodLogForDate(today) } returns periodLog
+
+        // WHEN
+        vm.onEvent(TrackerEvent.PeriodMarkDay(today))
+        advanceUntilIdle()
+
+        // THEN — confirmation dialog shown, unLogPeriodDay NOT called
+        assertTrue(vm.uiState.value.showUnmarkConfirmation)
+        assertEquals(today, vm.uiState.value.unmarkDate)
+        coVerify(exactly = 0) { mockRepository.unLogPeriodDay(any()) }
+    }
+
+    @Test
+    fun onEvent_PeriodMarkDay_WHEN_dayHasNoData_THEN_proceedsSilently() = runTest {
+        // GIVEN — a period exists, period log has no data
+        val period = Period("p1", today.minus(2, DateTimeUnit.DAY), today.plus(2, DateTimeUnit.DAY), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        val periodLog = buildPeriodLog(flowIntensity = null, periodColor = null, periodConsistency = null)
+        coEvery { mockRepository.getPeriodLogForDate(today) } returns periodLog
+
+        // WHEN
+        vm.onEvent(TrackerEvent.PeriodMarkDay(today))
+        advanceUntilIdle()
+
+        // THEN — proceeds silently
+        assertFalse(vm.uiState.value.showUnmarkConfirmation)
+        coVerify(exactly = 1) { mockRepository.unLogPeriodDay(today) }
+    }
+
+    @Test
+    fun onEvent_PeriodMarkDay_WHEN_noPeriodLogExists_THEN_proceedsSilently() = runTest {
+        // GIVEN — a period exists, but no period log for that date
+        val period = Period("p1", today.minus(2, DateTimeUnit.DAY), today.plus(2, DateTimeUnit.DAY), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        coEvery { mockRepository.getPeriodLogForDate(today) } returns null
+
+        // WHEN
+        vm.onEvent(TrackerEvent.PeriodMarkDay(today))
+        advanceUntilIdle()
+
+        // THEN — proceeds silently
+        assertFalse(vm.uiState.value.showUnmarkConfirmation)
+        coVerify(exactly = 1) { mockRepository.unLogPeriodDay(today) }
+    }
+
+    @Test
+    fun onEvent_UnmarkPeriodDayConfirmed_THEN_callsUnLogAndResetsState() = runTest {
+        // GIVEN — confirmation dialog is showing
+        val period = Period("p1", today.minus(2, DateTimeUnit.DAY), today.plus(2, DateTimeUnit.DAY), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        val periodLog = buildPeriodLog(flowIntensity = FlowIntensity.MEDIUM)
+        coEvery { mockRepository.getPeriodLogForDate(today) } returns periodLog
+
+        vm.onEvent(TrackerEvent.PeriodMarkDay(today))
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.showUnmarkConfirmation)
+
+        // WHEN
+        vm.onEvent(TrackerEvent.UnmarkPeriodDayConfirmed(today))
+        advanceUntilIdle()
+
+        // THEN
+        coVerify(exactly = 1) { mockRepository.unLogPeriodDay(today) }
+        assertFalse(vm.uiState.value.showUnmarkConfirmation)
+        assertNull(vm.uiState.value.unmarkDate)
+    }
+
+    @Test
+    fun onEvent_UnmarkPeriodDismissed_THEN_resetsDialogState() = runTest {
+        // GIVEN — confirmation dialog is showing
+        val period = Period("p1", today.minus(2, DateTimeUnit.DAY), today.plus(2, DateTimeUnit.DAY), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        val periodLog = buildPeriodLog(flowIntensity = FlowIntensity.LIGHT)
+        coEvery { mockRepository.getPeriodLogForDate(today) } returns periodLog
+
+        vm.onEvent(TrackerEvent.PeriodMarkDay(today))
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.showUnmarkConfirmation)
+
+        // WHEN
+        vm.onEvent(TrackerEvent.UnmarkPeriodDismissed)
+        advanceUntilIdle()
+
+        // THEN
+        assertFalse(vm.uiState.value.showUnmarkConfirmation)
+        assertNull(vm.uiState.value.unmarkDate)
+        coVerify(exactly = 0) { mockRepository.unLogPeriodDay(any()) }
+    }
+
+    @Test
+    fun onEvent_PeriodRangeDragged_WHEN_shrinkWithDataDays_THEN_showsMultiDayDialog() = runTest {
+        // GIVEN — period June 10–15, some days have data
+        val period = Period("p1", LocalDate(2025, 6, 10), LocalDate(2025, 6, 15), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        // Two period logs with data out of 2 days being removed (June 10, 11)
+        val logsWithData = listOf(
+            buildPeriodLog(entryId = "e1", flowIntensity = FlowIntensity.HEAVY),
+            buildPeriodLog(entryId = "e2", flowIntensity = null, periodColor = null, periodConsistency = null),
+        )
+        coEvery { mockRepository.getPeriodLogsForDateRange(LocalDate(2025, 6, 10), LocalDate(2025, 6, 11)) } returns logsWithData
+
+        // WHEN — shrink from start
+        vm.onEvent(TrackerEvent.PeriodRangeDragged(LocalDate(2025, 6, 10), LocalDate(2025, 6, 12)))
+        advanceUntilIdle()
+
+        // THEN — multi-day confirmation dialog shown
+        assertTrue(vm.uiState.value.showUnmarkConfirmation)
+        assertEquals(2, vm.uiState.value.unmarkDates.size)
+        assertEquals(1, vm.uiState.value.unmarkDaysWithDataCount)
+        coVerify(exactly = 0) { mockRepository.unLogPeriodDay(any()) }
+    }
+
+    @Test
+    fun onEvent_PeriodRangeDragged_WHEN_shrinkWithNoDataDays_THEN_proceedsSilently() = runTest {
+        // GIVEN — period June 10–15, no days have data
+        val period = Period("p1", LocalDate(2025, 6, 10), LocalDate(2025, 6, 15), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        coEvery { mockRepository.getPeriodLogsForDateRange(any(), any()) } returns emptyList()
+
+        // WHEN — shrink from start
+        vm.onEvent(TrackerEvent.PeriodRangeDragged(LocalDate(2025, 6, 10), LocalDate(2025, 6, 12)))
+        advanceUntilIdle()
+
+        // THEN — proceeds silently
+        assertFalse(vm.uiState.value.showUnmarkConfirmation)
+        coVerify(exactly = 1) { mockRepository.unLogPeriodDay(LocalDate(2025, 6, 10)) }
+        coVerify(exactly = 1) { mockRepository.unLogPeriodDay(LocalDate(2025, 6, 11)) }
+    }
+
+    @Test
+    fun onEvent_UnmarkPeriodRangeConfirmed_THEN_callsUnLogForEachDate() = runTest {
+        // GIVEN — multi-day confirmation dialog is showing
+        val period = Period("p1", LocalDate(2025, 6, 10), LocalDate(2025, 6, 15), TestData.INSTANT, TestData.INSTANT)
+        val vm = viewModelWithPeriods(listOf(period))
+        advanceUntilIdle()
+
+        val logsWithData = listOf(
+            buildPeriodLog(flowIntensity = FlowIntensity.HEAVY),
+        )
+        coEvery { mockRepository.getPeriodLogsForDateRange(any(), any()) } returns logsWithData
+
+        vm.onEvent(TrackerEvent.PeriodRangeDragged(LocalDate(2025, 6, 10), LocalDate(2025, 6, 12)))
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.showUnmarkConfirmation)
+
+        // WHEN
+        val datesToRemove = vm.uiState.value.unmarkDates
+        vm.onEvent(TrackerEvent.UnmarkPeriodRangeConfirmed(datesToRemove))
+        advanceUntilIdle()
+
+        // THEN
+        for (date in datesToRemove) {
+            coVerify(exactly = 1) { mockRepository.unLogPeriodDay(date) }
+        }
+        assertFalse(vm.uiState.value.showUnmarkConfirmation)
+        assertTrue(vm.uiState.value.unmarkDates.isEmpty())
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/tracker/UnmarkPeriodConfirmationDialogTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/tracker/UnmarkPeriodConfirmationDialogTest.kt
@@ -1,0 +1,223 @@
+package com.veleda.cyclewise.ui.tracker
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.veleda.cyclewise.RobolectricTestApp
+import com.veleda.cyclewise.testutil.TestData
+import com.veleda.cyclewise.ui.theme.Dimensions
+import com.veleda.cyclewise.ui.theme.LocalDimensions
+import kotlinx.datetime.LocalDate
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-based Compose UI tests for [UnmarkPeriodDayConfirmationDialog]
+ * and [UnmarkPeriodRangeConfirmationDialog].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricTestApp::class)
+class UnmarkPeriodConfirmationDialogTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // ── Single-day dialog tests ──────────────────────────────────────
+
+    private fun setSingleDayContent(
+        showUnmarkConfirmation: Boolean = false,
+        unmarkDate: LocalDate? = null,
+        onEvent: (TrackerEvent) -> Unit = {},
+    ) {
+        val uiState = TrackerUiState(
+            showUnmarkConfirmation = showUnmarkConfirmation,
+            unmarkDate = unmarkDate,
+            unmarkDates = emptyList(),
+            unmarkDaysWithDataCount = 1,
+        )
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    UnmarkPeriodDayConfirmationDialog(
+                        uiState = uiState,
+                        onEvent = onEvent,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun singleDayDialog_WHEN_showFalse_THEN_notDisplayed() {
+        // Given / When
+        setSingleDayContent(showUnmarkConfirmation = false, unmarkDate = TestData.DATE)
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Day?").assertDoesNotExist()
+    }
+
+    @Test
+    fun singleDayDialog_WHEN_unmarkDateNull_THEN_notDisplayed() {
+        // Given / When
+        setSingleDayContent(showUnmarkConfirmation = true, unmarkDate = null)
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Day?").assertDoesNotExist()
+    }
+
+    @Test
+    fun singleDayDialog_WHEN_showTrueAndDateNonNull_THEN_displayed() {
+        // Given / When
+        setSingleDayContent(showUnmarkConfirmation = true, unmarkDate = TestData.DATE)
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Day?").assertIsDisplayed()
+    }
+
+    @Test
+    fun singleDayDialog_WHEN_confirmTapped_THEN_dispatchesUnmarkDayConfirmed() {
+        // Given
+        val events = mutableListOf<TrackerEvent>()
+        setSingleDayContent(
+            showUnmarkConfirmation = true,
+            unmarkDate = TestData.DATE,
+            onEvent = { events.add(it) },
+        )
+
+        // When
+        composeTestRule.onNodeWithText("Remove").performClick()
+
+        // Then
+        val confirmed = events.filterIsInstance<TrackerEvent.UnmarkPeriodDayConfirmed>()
+        assert(confirmed.isNotEmpty()) { "UnmarkPeriodDayConfirmed event not dispatched" }
+        assert(confirmed.first().date == TestData.DATE) {
+            "Expected date ${TestData.DATE}, got ${confirmed.first().date}"
+        }
+    }
+
+    @Test
+    fun singleDayDialog_WHEN_cancelTapped_THEN_dispatchesUnmarkDismissed() {
+        // Given
+        val events = mutableListOf<TrackerEvent>()
+        setSingleDayContent(
+            showUnmarkConfirmation = true,
+            unmarkDate = TestData.DATE,
+            onEvent = { events.add(it) },
+        )
+
+        // When
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        // Then
+        val dismissed = events.filterIsInstance<TrackerEvent.UnmarkPeriodDismissed>()
+        assert(dismissed.isNotEmpty()) { "UnmarkPeriodDismissed event not dispatched" }
+    }
+
+    // ── Multi-day dialog tests ───────────────────────────────────────
+
+    private fun setMultiDayContent(
+        showUnmarkConfirmation: Boolean = false,
+        unmarkDates: List<LocalDate> = emptyList(),
+        unmarkDaysWithDataCount: Int = 0,
+        onEvent: (TrackerEvent) -> Unit = {},
+    ) {
+        val uiState = TrackerUiState(
+            showUnmarkConfirmation = showUnmarkConfirmation,
+            unmarkDate = null,
+            unmarkDates = unmarkDates,
+            unmarkDaysWithDataCount = unmarkDaysWithDataCount,
+        )
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    UnmarkPeriodRangeConfirmationDialog(
+                        uiState = uiState,
+                        onEvent = onEvent,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun multiDayDialog_WHEN_showFalse_THEN_notDisplayed() {
+        // Given / When
+        setMultiDayContent(
+            showUnmarkConfirmation = false,
+            unmarkDates = listOf(TestData.DATE, TestData.DATE_YESTERDAY),
+        )
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Days?").assertDoesNotExist()
+    }
+
+    @Test
+    fun multiDayDialog_WHEN_unmarkDatesEmpty_THEN_notDisplayed() {
+        // Given / When
+        setMultiDayContent(showUnmarkConfirmation = true, unmarkDates = emptyList())
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Days?").assertDoesNotExist()
+    }
+
+    @Test
+    fun multiDayDialog_WHEN_showTrueAndDatesNonEmpty_THEN_displayed() {
+        // Given / When
+        setMultiDayContent(
+            showUnmarkConfirmation = true,
+            unmarkDates = listOf(TestData.DATE, TestData.DATE_YESTERDAY),
+            unmarkDaysWithDataCount = 1,
+        )
+
+        // Then
+        composeTestRule.onNodeWithText("Remove Period Days?").assertIsDisplayed()
+    }
+
+    @Test
+    fun multiDayDialog_WHEN_confirmTapped_THEN_dispatchesUnmarkRangeConfirmed() {
+        // Given
+        val events = mutableListOf<TrackerEvent>()
+        val dates = listOf(TestData.DATE, TestData.DATE_YESTERDAY)
+        setMultiDayContent(
+            showUnmarkConfirmation = true,
+            unmarkDates = dates,
+            unmarkDaysWithDataCount = 1,
+            onEvent = { events.add(it) },
+        )
+
+        // When — tap the "Remove 2 Days" button
+        composeTestRule.onNodeWithText("Remove 2 Days").performClick()
+
+        // Then
+        val confirmed = events.filterIsInstance<TrackerEvent.UnmarkPeriodRangeConfirmed>()
+        assert(confirmed.isNotEmpty()) { "UnmarkPeriodRangeConfirmed event not dispatched" }
+        assert(confirmed.first().dates == dates) {
+            "Expected dates $dates, got ${confirmed.first().dates}"
+        }
+    }
+
+    @Test
+    fun multiDayDialog_WHEN_cancelTapped_THEN_dispatchesUnmarkDismissed() {
+        // Given
+        val events = mutableListOf<TrackerEvent>()
+        setMultiDayContent(
+            showUnmarkConfirmation = true,
+            unmarkDates = listOf(TestData.DATE, TestData.DATE_YESTERDAY),
+            unmarkDaysWithDataCount = 1,
+            onEvent = { events.add(it) },
+        )
+
+        // When
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        // Then
+        val dismissed = events.filterIsInstance<TrackerEvent.UnmarkPeriodDismissed>()
+        assert(dismissed.isNotEmpty()) { "UnmarkPeriodDismissed event not dispatched" }
+    }
+}

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -3,32 +3,34 @@
   <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>ComplexInterface:PeriodRepository.kt$PeriodRepository</ID>
-    <ID>CyclomaticComplexMethod:CalendarDay.kt$@Composable internal fun CalendarDayCell( day: CalendarDay, dayInfo: CalendarDayInfo?, isToday: Boolean, isStartDate: Boolean, isEndDate: Boolean, isInExistingRange: Boolean, isInSelectionRange: Boolean, isInRemovalRange: Boolean = false, isDragging: Boolean = false, isPhaseStart: Boolean = true, isPhaseEnd: Boolean = true, palette: CyclePhasePalette, displayPhase: CyclePhase? = null, onTap: (() -&gt; Unit)?, boundsRegistry: DayBoundsRegistry? = null, cellAspectRatio: Float = 1f, )</ID>
+    <ID>CyclomaticComplexMethod:CalendarDay.kt$@Composable internal fun CalendarDayCell( day: CalendarDay, dayInfo: CalendarDayInfo?, isToday: Boolean, isStartDate: Boolean, isEndDate: Boolean, isInExistingRange: Boolean, isInSelectionRange: Boolean, isInRemovalRange: Boolean = false, isDragging: Boolean = false, isPhaseStart: Boolean = true, isPhaseEnd: Boolean = true, palette: CyclePhasePalette, displayPhase: CyclePhase? = null, onTap: (() -&gt; Unit)?, boundsRegistry: DayBoundsRegistry? = null, cellAspectRatio: Float = 1f, heatmapColor: Color? = null, )</ID>
     <ID>CyclomaticComplexMethod:CalendarGrid.kt$@Composable internal fun CalendarGrid( uiState: TrackerUiState, calendarState: CalendarState, palette: CyclePhasePalette, phaseVisible: Map&lt;CyclePhase, Boolean&gt;, today: LocalDate, boundsRegistry: DayBoundsRegistry, isDragging: Boolean, dragAnchor: LocalDate?, dragCurrent: LocalDate?, activeHint: ActiveCoachMark?, pendingKey: HintKey?, coachMarkState: CoachMarkState, calendarBoxCoords: LayoutCoordinates?, onCalendarBoxPositioned: (LayoutCoordinates) -&gt; Unit, onDragStateChanged: (anchor: LocalDate?, current: LocalDate?, dragging: Boolean) -&gt; Unit, onEvent: (TrackerEvent) -&gt; Unit, onTutorialAdvance: () -&gt; Unit = {}, modifier: Modifier = Modifier, )</ID>
     <ID>CyclomaticComplexMethod:CyclePhaseCalculator.kt$CyclePhaseCalculator$fun calculatePhase( date: LocalDate, periods: List&lt;Period&gt;, averageCycleLength: Double? ): CyclePhase?</ID>
     <ID>CyclomaticComplexMethod:DailyLogScreen.kt$@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class) @Composable fun DailyLogScreen( date: LocalDate, onNavigateToTracker: () -&gt; Unit = {}, )</ID>
+    <ID>CyclomaticComplexMethod:DailyLogViewModel.kt$DailyLogViewModel$fun onEvent(event: DailyLogEvent)</ID>
     <ID>CyclomaticComplexMethod:DailyLogViewModel.kt$DailyLogViewModel$private fun reduce(currentState: DailyLogUiState, event: DailyLogEvent): DailyLogUiState</ID>
     <ID>CyclomaticComplexMethod:LogSummarySheet.kt$@Composable internal fun LogSummarySheetContent( log: FullDailyLog, periodId: String?, cyclePhase: CyclePhase? = null, symptomLibrary: List&lt;Symptom&gt;, medicationLibrary: List&lt;Medication&gt;, waterCups: Int?, showMood: Boolean, showEnergy: Boolean, showLibido: Boolean, onEditClick: (LocalDate) -&gt; Unit, onDeleteClick: (String) -&gt; Unit, onViewFullLogClick: (LocalDate) -&gt; Unit )</ID>
-    <ID>CyclomaticComplexMethod:MoodPhasePatternGenerator.kt$MoodPhasePatternGenerator$override fun generate(data: InsightData): List&lt;Insight&gt;</ID>
     <ID>CyclomaticComplexMethod:RoomPeriodRepository.kt$RoomPeriodRepository$override suspend fun seedDatabaseForDebug()</ID>
     <ID>CyclomaticComplexMethod:SettingsViewModel.kt$SettingsViewModel$fun onEvent(event: SettingsEvent)</ID>
-    <ID>CyclomaticComplexMethod:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$@OptIn(ExperimentalTime::class) override fun generate(data: InsightData): List&lt;Insight&gt;</ID>
     <ID>CyclomaticComplexMethod:TrackerScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun TrackerScreen(navController: NavController)</ID>
     <ID>CyclomaticComplexMethod:TrackerViewModel.kt$TrackerViewModel$fun onEvent(event: TrackerEvent)</ID>
     <ID>LongMethod:AboutPage.kt$@Composable internal fun AboutPage( state: AboutSettingsState, onEvent: (SettingsEvent) -&gt; Unit, isSessionActive: Boolean, onSeedDebugData: (() -&gt; DebugSeederUseCase?)? = null, )</ID>
     <ID>LongMethod:AppearancePage.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable internal fun AppearancePage( state: AppearanceSettingsState, onEvent: (SettingsEvent) -&gt; Unit, )</ID>
-    <ID>LongMethod:CalendarDay.kt$@Composable internal fun CalendarDayCell( day: CalendarDay, dayInfo: CalendarDayInfo?, isToday: Boolean, isStartDate: Boolean, isEndDate: Boolean, isInExistingRange: Boolean, isInSelectionRange: Boolean, isInRemovalRange: Boolean = false, isDragging: Boolean = false, isPhaseStart: Boolean = true, isPhaseEnd: Boolean = true, palette: CyclePhasePalette, displayPhase: CyclePhase? = null, onTap: (() -&gt; Unit)?, boundsRegistry: DayBoundsRegistry? = null, cellAspectRatio: Float = 1f, )</ID>
+    <ID>LongMethod:CalendarDay.kt$@Composable internal fun CalendarDayCell( day: CalendarDay, dayInfo: CalendarDayInfo?, isToday: Boolean, isStartDate: Boolean, isEndDate: Boolean, isInExistingRange: Boolean, isInSelectionRange: Boolean, isInRemovalRange: Boolean = false, isDragging: Boolean = false, isPhaseStart: Boolean = true, isPhaseEnd: Boolean = true, palette: CyclePhasePalette, displayPhase: CyclePhase? = null, onTap: (() -&gt; Unit)?, boundsRegistry: DayBoundsRegistry? = null, cellAspectRatio: Float = 1f, heatmapColor: Color? = null, )</ID>
     <ID>LongMethod:CalendarGrid.kt$@Composable internal fun CalendarGrid( uiState: TrackerUiState, calendarState: CalendarState, palette: CyclePhasePalette, phaseVisible: Map&lt;CyclePhase, Boolean&gt;, today: LocalDate, boundsRegistry: DayBoundsRegistry, isDragging: Boolean, dragAnchor: LocalDate?, dragCurrent: LocalDate?, activeHint: ActiveCoachMark?, pendingKey: HintKey?, coachMarkState: CoachMarkState, calendarBoxCoords: LayoutCoordinates?, onCalendarBoxPositioned: (LayoutCoordinates) -&gt; Unit, onDragStateChanged: (anchor: LocalDate?, current: LocalDate?, dragging: Boolean) -&gt; Unit, onEvent: (TrackerEvent) -&gt; Unit, onTutorialAdvance: () -&gt; Unit = {}, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:CoachMarkOverlay.kt$@Composable fun CoachMarkOverlay( state: CoachMarkState, allDefs: Map&lt;HintKey, CoachMarkDef&gt;, stepList: List&lt;HintKey&gt;, onSkipAll: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:CycleWiseAppUI.kt$@Composable @Preview fun CycleWiseAppUI()</ID>
     <ID>LongMethod:DailyLogScreen.kt$@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class) @Composable fun DailyLogScreen( date: LocalDate, onNavigateToTracker: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:DailyLogViewModel.kt$DailyLogViewModel$fun onEvent(event: DailyLogEvent)</ID>
     <ID>LongMethod:DailyLogViewModel.kt$DailyLogViewModel$private fun reduce(currentState: DailyLogUiState, event: DailyLogEvent): DailyLogUiState</ID>
+    <ID>LongMethod:EmptyStateOverlay.kt$@Composable fun EmptyStateOverlay( onDismissed: () -&gt; Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:GeneralPage.kt$@Composable private fun ChangePassphraseDialog( state: GeneralSettingsState, onEvent: (SettingsEvent) -&gt; Unit, )</ID>
     <ID>LongMethod:GeneralPage.kt$@Composable private fun ChangePassphraseFields( state: GeneralSettingsState, current: String, onCurrentChange: (String) -&gt; Unit, newPassphrase: String, onNewPassphraseChange: (String) -&gt; Unit, confirmation: String, onConfirmationChange: (String) -&gt; Unit, )</ID>
     <ID>LongMethod:GeneralPage.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable internal fun GeneralPage( state: GeneralSettingsState, onEvent: (SettingsEvent) -&gt; Unit, isSessionActive: Boolean, onLockNow: () -&gt; Unit, )</ID>
     <ID>LongMethod:InsightsScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable internal fun InsightsContent( uiState: InsightsUiState, onRefresh: () -&gt; Unit, onEvent: (InsightsEvent) -&gt; Unit, modifier: Modifier = Modifier )</ID>
+    <ID>LongMethod:InsightsViewModel.kt$InsightsViewModel$private fun loadInsights(isRefresh: Boolean)</ID>
     <ID>LongMethod:LogSummarySheet.kt$@Composable internal fun LogSummarySheetContent( log: FullDailyLog, periodId: String?, cyclePhase: CyclePhase? = null, symptomLibrary: List&lt;Symptom&gt;, medicationLibrary: List&lt;Medication&gt;, waterCups: Int?, showMood: Boolean, showEnergy: Boolean, showLibido: Boolean, onEditClick: (LocalDate) -&gt; Unit, onDeleteClick: (String) -&gt; Unit, onViewFullLogClick: (LocalDate) -&gt; Unit )</ID>
+    <ID>LongMethod:MedicationsPage.kt$@OptIn(ExperimentalLayoutApi::class) @Composable internal fun MedicationLogger( loggedMedications: List&lt;MedicationLog&gt;, medicationLibrary: List&lt;Medication&gt;, onToggleMedication: (Medication) -&gt; Unit, onCreateAndAddMedication: (String) -&gt; Unit, medicationForContextMenu: Medication? = null, onMedicationLongPressed: (Medication) -&gt; Unit = {}, onRenameClicked: (Medication) -&gt; Unit = {}, onDeleteClicked: (Medication) -&gt; Unit = {}, onEditDismissed: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:PassPhraseScreen.kt$@Composable internal fun UnlockScreen( uiState: PassphraseUiState, onEvent: (PassphraseEvent) -&gt; Unit, effect: SharedFlow&lt;PassphraseEffect&gt;, )</ID>
     <ID>LongMethod:PeriodPage.kt$@Composable internal fun PeriodPage( isPeriodDay: Boolean, flowIntensity: FlowIntensity?, periodColor: PeriodColor?, periodConsistency: PeriodConsistency?, onPeriodToggled: (Boolean) -&gt; Unit, onFlowChanged: (FlowIntensity?) -&gt; Unit, onColorChanged: (PeriodColor?) -&gt; Unit, onConsistencyChanged: (PeriodConsistency?) -&gt; Unit, onShowEducationalSheet: (String) -&gt; Unit, coachMarkState: CoachMarkState? = null, activeHintKey: HintKey? = null, )</ID>
     <ID>LongMethod:PhaseColorSettings.kt$@Composable fun PhaseColorSettings( menstruationHex: String, follicularHex: String, ovulationHex: String, lutealHex: String, onMenstruationColorChanged: (String) -&gt; Unit, onFollicularColorChanged: (String) -&gt; Unit, onOvulationColorChanged: (String) -&gt; Unit, onLutealColorChanged: (String) -&gt; Unit, onResetDefaults: () -&gt; Unit, showTitle: Boolean = true, )</ID>
@@ -38,15 +40,26 @@
     <ID>LongMethod:SetupScreen.kt$@Composable fun SetupScreen( uiState: PassphraseUiState, onEvent: (PassphraseEvent) -&gt; Unit, )</ID>
     <ID>LongMethod:SetupScreen.kt$@Composable private fun CreatePassphrasePage( uiState: PassphraseUiState, onEvent: (PassphraseEvent) -&gt; Unit, )</ID>
     <ID>LongMethod:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$@OptIn(ExperimentalTime::class) override fun generate(data: InsightData): List&lt;Insight&gt;</ID>
+    <ID>LongMethod:SymptomsPage.kt$@OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class) @Composable internal fun SymptomLogger( loggedSymptoms: List&lt;SymptomLog&gt;, symptomLibrary: List&lt;Symptom&gt;, onToggleSymptom: (Symptom) -&gt; Unit, onCreateAndAddSymptom: (String) -&gt; Unit, symptomForContextMenu: Symptom? = null, onSymptomLongPressed: (Symptom) -&gt; Unit = {}, onRenameClicked: (Symptom) -&gt; Unit = {}, onDeleteClicked: (Symptom) -&gt; Unit = {}, onEditDismissed: () -&gt; Unit = {}, )</ID>
     <ID>LongMethod:TrackerScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun TrackerScreen(navController: NavController)</ID>
     <ID>LongMethod:TrackerViewModel.kt$TrackerViewModel$fun onEvent(event: TrackerEvent)</ID>
     <ID>LongMethod:TutorialSeederUseCase.kt$TutorialSeederUseCase$suspend operator fun invoke(): SeedManifest?</ID>
     <ID>LongMethod:WellnessPage.kt$@Composable internal fun WellnessPage( moodScore: Int?, energyLevel: Int?, libidoScore: Int?, waterCups: Int, onMoodChanged: (Int) -&gt; Unit, onEnergyChanged: (Int) -&gt; Unit, onLibidoChanged: (Int) -&gt; Unit, onWaterIncrement: () -&gt; Unit, onWaterDecrement: () -&gt; Unit, onShowEducationalSheet: (String) -&gt; Unit, coachMarkState: CoachMarkState? = null, activeHintKey: HintKey? = null, )</ID>
+    <ID>LongParameterList:DailyLogViewModel.kt$DailyLogViewModel$( private val entryDate: LocalDate, private val periodRepository: PeriodRepository, private val getOrCreateDailyLog: GetOrCreateDailyLogUseCase, private val symptomLibraryProvider: SymptomLibraryProvider, private val medicationLibraryProvider: MedicationLibraryProvider, private val educationalContentProvider: EducationalContentProvider, private val renameSymptomUseCase: RenameSymptomUseCase, private val deleteSymptomUseCase: DeleteSymptomUseCase, private val renameMedicationUseCase: RenameMedicationUseCase, private val deleteMedicationUseCase: DeleteMedicationUseCase, )</ID>
+    <ID>MagicNumber:CorrelationEngine.kt$CorrelationEngine$3.0</ID>
     <ID>MagicNumber:CycleLengthTrendGenerator.kt$CycleLengthTrendGenerator$3</ID>
     <ID>MagicNumber:CyclePhaseColors.kt$0x00FFFFFF</ID>
     <ID>MagicNumber:CyclePhaseColors.kt$0xFF000000</ID>
+    <ID>MagicNumber:HeatmapMetric.kt$HeatmapMetric.Energy$4f</ID>
+    <ID>MagicNumber:HeatmapMetric.kt$HeatmapMetric.FlowIntensity$0.33f</ID>
+    <ID>MagicNumber:HeatmapMetric.kt$HeatmapMetric.FlowIntensity$0.66f</ID>
+    <ID>MagicNumber:HeatmapMetric.kt$HeatmapMetric.Libido$4f</ID>
+    <ID>MagicNumber:HeatmapMetric.kt$HeatmapMetric.Mood$4f</ID>
+    <ID>MagicNumber:HeatmapMetric.kt$HeatmapMetric.SymptomSeverity$4f</ID>
     <ID>MagicNumber:Migration_10_11.kt$Migration_10_11$10</ID>
     <ID>MagicNumber:Migration_10_11.kt$Migration_10_11$11</ID>
+    <ID>MagicNumber:Migration_11_12.kt$Migration_11_12$11</ID>
+    <ID>MagicNumber:Migration_11_12.kt$Migration_11_12$12</ID>
     <ID>MagicNumber:Migration_2_3.kt$Migration_2_3$3</ID>
     <ID>MagicNumber:Migration_3_4.kt$Migration_3_4$3</ID>
     <ID>MagicNumber:Migration_3_4.kt$Migration_3_4$4</ID>
@@ -62,8 +75,6 @@
     <ID>MagicNumber:Migration_8_9.kt$Migration_8_9$9</ID>
     <ID>MagicNumber:Migration_9_10.kt$Migration_9_10$10</ID>
     <ID>MagicNumber:Migration_9_10.kt$Migration_9_10$9</ID>
-    <ID>MagicNumber:MoodPhasePatternGenerator.kt$MoodPhasePatternGenerator$3</ID>
-    <ID>MagicNumber:MoodPhasePatternGenerator.kt$MoodPhasePatternGenerator$8</ID>
     <ID>MagicNumber:RoomPeriodRepository.kt$RoomPeriodRepository$0.15f</ID>
     <ID>MagicNumber:RoomPeriodRepository.kt$RoomPeriodRepository$0.1f</ID>
     <ID>MagicNumber:RoomPeriodRepository.kt$RoomPeriodRepository$0.5f</ID>
@@ -79,7 +90,6 @@
     <ID>MagicNumber:RoomPeriodRepository.kt$RoomPeriodRepository$6</ID>
     <ID>MagicNumber:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$0.70</ID>
     <ID>MagicNumber:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$0.85</ID>
-    <ID>MagicNumber:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$8</ID>
     <ID>MagicNumber:SymptomRecurrenceGenerator.kt$SymptomRecurrenceGenerator$3</ID>
     <ID>MagicNumber:TutorialSeederUseCase.kt$TutorialSeederUseCase$3</ID>
     <ID>MagicNumber:TutorialSeederUseCase.kt$TutorialSeederUseCase$4</ID>
@@ -88,13 +98,18 @@
     <ID>MaxLineLength:DailyLogScreen.kt$PAGE_PERIOD -&gt; Modifier.coachMarkTarget(HintKey.DAILY_LOG_PERIOD_TAB, coachMarkState)</ID>
     <ID>MaxLineLength:DailyLogScreen.kt$onConsistencyChanged = { viewModel.onEvent(DailyLogEvent.PeriodConsistencyChanged(it)) }</ID>
     <ID>MaxLineLength:DailyLogScreen.kt$onCreateAndAddMedication = { viewModel.onEvent(DailyLogEvent.MedicationCreatedAndAdded(it)) }</ID>
+    <ID>MaxLineLength:DailyLogScreen.kt$onMedicationLongPressed = { viewModel.onEvent(DailyLogEvent.MedicationLongPressed(it)) }</ID>
+    <ID>MaxLineLength:DailyLogScreen.kt$onRenameConfirmed = { id, name -&gt; viewModel.onEvent(DailyLogEvent.RenameMedicationConfirmed(id, name)) }</ID>
+    <ID>MaxLineLength:DailyLogScreen.kt$onRenameConfirmed = { id, name -&gt; viewModel.onEvent(DailyLogEvent.RenameSymptomConfirmed(id, name)) }</ID>
     <ID>MaxLineLength:DailyLogScreen.kt$onShowEducationalSheet = { tag -&gt; viewModel.onEvent(DailyLogEvent.ShowEducationalSheet(tag)) }</ID>
-    <ID>MaxLineLength:DailyLogViewModel.kt$DailyLogViewModel$is DailyLogEvent.LogLoaded, is DailyLogEvent.LibraryUpdated, is DailyLogEvent.SymptomNameChanged -&gt; currentState</ID>
+    <ID>MaxLineLength:DailyLogViewModel.kt$DailyLogViewModel$log.copy(medicationLogs = log.medicationLogs.filterNot { ml -&gt; ml.medicationId == event.medicationId })</ID>
     <ID>MaxLineLength:DailyLogViewModel.kt$DailyLogViewModel$log.medicationLogs + MedicationLog(uuid4().toString(), log.entry.id, event.medication.id, Clock.System.now())</ID>
     <ID>MaxLineLength:DailyLogViewModel.kt$DailyLogViewModel$log.symptomLogs + SymptomLog(uuid4().toString(), log.entry.id, event.symptom.id, 3, Clock.System.now())</ID>
     <ID>MaxLineLength:Insight.kt$CycleLengthAverage$override val description: String = "Based on completed cycles, your average cycle length is ${averageDays.roundToInt()} days."</ID>
     <ID>MaxLineLength:Insight.kt$MoodPhasePattern$val baseDescription = "You've logged a '$moodType' mood $phaseDescription in $recurrenceRate of your recent cycles."</ID>
+    <ID>MaxLineLength:Insight.kt$SymptomSeverityTrend$"(${String.format("%.1f", avgSeverityRecent)} vs ${String.format("%.1f", avgSeverityOlder)} in earlier cycles)."</ID>
     <ID>MaxLineLength:Mappers.kt$fun</ID>
+    <ID>MaxLineLength:Migration_11_12.kt$Migration_11_12$db.execSQL("CREATE INDEX IF NOT EXISTS `index_medication_logs_medication_id` ON `medication_logs`(`medication_id`)")</ID>
     <ID>MaxLineLength:Migration_4_5.kt$Migration_4_5$db.execSQL("CREATE INDEX IF NOT EXISTS `index_medication_logs_medication_id` ON `medication_logs` (`medication_id`)")</ID>
     <ID>MaxLineLength:Migration_5_6.kt$Migration_5_6$db.execSQL("INSERT INTO symptom_library (id, name, category, created_at) VALUES (?, ?, ?, ?)", arrayOf(newUuid, name, "OTHER", now))</ID>
     <ID>MaxLineLength:Migration_5_6.kt$Migration_5_6$db.execSQL("INSERT INTO symptom_logs (id, entry_id, symptom_id, severity, created_at) VALUES (?, ?, ?, ?, ?)", arrayOf(logId, entryId, symptomUuid, severity, now))</ID>
@@ -111,14 +126,10 @@
     <ID>MaxLineLength:RoomPeriodRepository.kt$RoomPeriodRepository$symptomLogs.add(SymptomLog(uuid4().toString(), entryId, headache.id, Random.nextInt(1, 4), Clock.System.now()))</ID>
     <ID>MaxLineLength:RoomPeriodRepository.kt$RoomPeriodRepository$val allMedicationLogs = medicationLogDao.getLogsForEntries(entryIds).firstOrNull()?.groupBy { it.entryId } ?: emptyMap()</ID>
     <ID>MaxLineLength:RoomPeriodRepository.kt$RoomPeriodRepository$val allSymptomLogs = symptomLogDao.getLogsForEntries(entryIds).firstOrNull()?.groupBy { it.entryId } ?: emptyMap()</ID>
-    <ID>MaxLineLength:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$val avgPeriodLength = periods.mapNotNull { it.endDate?.let { endDate -&gt; it.startDate.daysUntil(endDate) } }.average().toInt()</ID>
-    <ID>MaxLineLength:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$val predictedCycleStart = nextPeriodPrediction.predictedDate.plus(-(data.averageCycleLength?.toInt() ?: 28), DateTimeUnit.DAY)</ID>
-    <ID>MaxLineLength:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$val recurrenceCount = group.mapNotNull { day -&gt; significantPatterns[Pair(symptomId, day)] }.minOrNull() ?: 0</ID>
     <ID>MaxLineLength:TrackerScreen.kt$contentDescription = stringResource(R.string.educational_info_button_cd, stringResource(R.string.tracker_phase_label))</ID>
     <ID>MaxLineLength:TrackerScreen.kt$val menstruationHex by appSettings.menstruationColor.collectAsState(initial = CyclePhaseColors.DEFAULT_MENSTRUATION_HEX)</ID>
     <ID>MaxLineLength:TutorialSeederUseCase.kt$TutorialSeederUseCase$val c1Flows = listOf(FlowIntensity.MEDIUM, FlowIntensity.HEAVY, FlowIntensity.HEAVY, FlowIntensity.MEDIUM, FlowIntensity.LIGHT)</ID>
     <ID>MaxLineLength:TutorialSeederUseCase.kt$TutorialSeederUseCase$val c3Flows = listOf(FlowIntensity.MEDIUM, FlowIntensity.HEAVY, FlowIntensity.HEAVY, FlowIntensity.MEDIUM, FlowIntensity.LIGHT)</ID>
-    <ID>NestedBlockDepth:SymptomPhasePatternGenerator.kt$SymptomPhasePatternGenerator$@OptIn(ExperimentalTime::class) override fun generate(data: InsightData): List&lt;Insight&gt;</ID>
     <ID>ReturnCount:CyclePhaseCalculator.kt$CyclePhaseCalculator$fun calculatePhase( date: LocalDate, periods: List&lt;Period&gt;, averageCycleLength: Double? ): CyclePhase?</ID>
     <ID>ReturnCount:DailyLogViewModel.kt$DailyLogViewModel$private fun reduce(currentState: DailyLogUiState, event: DailyLogEvent): DailyLogUiState</ID>
     <ID>TooManyFunctions:AppSettings.kt$AppSettings</ID>
@@ -132,14 +143,15 @@
     <ID>UnusedImports:Insight.kt$import kotlinx.datetime.TimeZone</ID>
     <ID>UnusedImports:Insight.kt$import kotlinx.datetime.daysUntil</ID>
     <ID>UnusedImports:Insight.kt$import kotlinx.datetime.todayIn</ID>
+    <ID>UnusedImports:InsightsScreen.kt$import com.veleda.cyclewise.domain.insights.InsightCategory</ID>
     <ID>UnusedImports:MedicationDao.kt$import com.veleda.cyclewise.androidData.local.entities.MedicationLogEntity</ID>
-    <ID>UnusedImports:MedicationsPage.kt$import androidx.compose.runtime.remember</ID>
     <ID>UnusedImports:Migration_4_5.kt$import com.benasher44.uuid.uuid4</ID>
     <ID>UnusedImports:Migration_7_8.kt$import kotlin.time.Clock</ID>
     <ID>UnusedImports:NotesTagsPage.kt$import androidx.compose.runtime.remember</ID>
     <ID>UnusedImports:RoomPeriodRepository.kt$import com.veleda.cyclewise.androidData.local.entities.PeriodEntity</ID>
     <ID>UnusedImports:SymptomEntity.kt$import androidx.room.ForeignKey</ID>
-    <ID>UnusedImports:SymptomsPage.kt$import androidx.compose.runtime.remember</ID>
+    <ID>UnusedImports:TrackerViewModel.kt$import com.veleda.cyclewise.domain.models.WaterIntake</ID>
+    <ID>UnusedImports:WaterIntakePhasePatternGenerator.kt$import kotlinx.datetime.daysUntil</ID>
     <ID>VariableNaming:AppSettings.kt$AppSettings$private val IS_PREPOPULATED = booleanPreferencesKey("is_prepopulated")</ID>
     <ID>VariableNaming:RoomPeriodRepository.kt$RoomPeriodRepository$val LATEST_PERIOD_START_DAYS_AGO = 28</ID>
     <ID>WildcardImport:AppModule.kt$import org.koin.core.module.dsl.*</ID>

--- a/docs/DeveloperOnboarding.md
+++ b/docs/DeveloperOnboarding.md
@@ -914,6 +914,7 @@ data class TrackerUiState(
 - `PeriodMarkDay(date)` — Long-press to toggle period day
 - `PeriodRangeDragged(anchorDate, releaseDate)` — Long-press-and-drag to mark/shrink a period range
 - `DeletePeriodRequested(periodId)` / `DeletePeriodConfirmed` / `DeletePeriodDismissed` — Delete confirmation flow
+- `UnmarkPeriodDayConfirmed(date)` / `UnmarkPeriodRangeConfirmed(dates)` / `UnmarkPeriodDismissed` — Unmark confirmation flow (shown when removing period days that have logged data)
 - ... and additional events for sheet dismissal, educational content, etc.
 
 **Dispatch:**
@@ -1558,7 +1559,13 @@ When the user interacts with the tracker:
 - **`DayTapped(date)`** — If a log exists for that date, shows a bottom sheet summary.
   If not, navigates to `DailyLogScreen` to create one.
 - **`PeriodMarkDay(date)`** — Long-press toggle. If the date is inside a period,
-  calls `unLogPeriodDay()`. If not, calls `logPeriodDay()`.
+  checks whether the day's `PeriodLog` has user-entered data (`hasData()`). If it
+  does, shows a confirmation dialog (`UnmarkPeriodDayConfirmationDialog`). If not,
+  calls `unLogPeriodDay()` silently. If the date is outside all periods, calls
+  `logPeriodDay()`.
+- **Unmark confirmation flow** — `UnmarkPeriodDayConfirmed(date)` calls
+  `unLogPeriodDay()`. `UnmarkPeriodRangeConfirmed(dates)` calls `unLogPeriodDay()`
+  for each date. `UnmarkPeriodDismissed` resets dialog state without side effects.
 - **Delete flow** — `DeletePeriodRequested` shows a confirmation dialog.
   `DeletePeriodConfirmed` calls `periodRepository.deletePeriod()`.
 
@@ -1579,11 +1586,13 @@ long-press, then tracks drag position. On release:
 
 **Shrink vs Expand logic in TrackerViewModel:** When processing `PeriodRangeDragged`:
 - **Shrink from start:** When anchor equals the start date of an existing period and
-  release is inside the period → calls `unLogPeriodDay()` for each day from anchor up
-  to (but not including) release.
+  release is inside the period → collects the days from anchor up to (but not
+  including) release. If any of those days have `PeriodLog` data (`hasData()`),
+  shows `UnmarkPeriodRangeConfirmationDialog` with counts. If none have data,
+  calls `unLogPeriodDay()` for each day silently.
 - **Shrink from end:** When anchor equals the end date of an existing period and
-  release is inside the period → calls `unLogPeriodDay()` for each day from anchor down
-  to (but not including) release.
+  release is inside the period → same data-check logic as shrink-from-start,
+  applied to the days from anchor down to (but not including) release.
 - **Default (expand/mark):** Otherwise → calls `logPeriodDay()` for every day in the
   anchor-to-release range (inclusive).
 
@@ -1823,10 +1832,12 @@ medication equivalents), period toggling (`PeriodToggled`), water tracking
 `LibraryUpdated`). See `DailyLogEvent.kt` for the complete sealed interface.
 
 > **PeriodLog lifecycle:** The `PeriodLog` is created (with null `flowIntensity`) by
-> `PeriodToggled` and deleted when the user toggles the period OFF. `FlowIntensityChanged`
-> only updates the flow field on an existing `PeriodLog` — it no longer creates or
-> deletes one. This allows users to log period attributes (color, consistency) without
-> first selecting a flow level.
+> `PeriodToggled` and deleted when the user toggles the period OFF. If the existing
+> `PeriodLog` has user-entered data (`hasData()` — flow, color, or consistency),
+> toggling OFF shows `UnmarkPeriodDayDialog` for confirmation instead of deleting
+> immediately. `FlowIntensityChanged` only updates the flow field on an existing
+> `PeriodLog` — it no longer creates or deletes one. This allows users to log period
+> attributes (color, consistency) without first selecting a flow level.
 
 ### The Pure Reducer
 
@@ -1840,7 +1851,9 @@ launched in `onEvent()` after the state update.
 | `MoodScoreChanged` | Yes | No |
 | `SymptomToggled` | Yes | No |
 | `CreateAndAddSymptom` | Returns `currentState` | Yes — creates symptom in library, then updates state |
-| `PeriodToggled` | Yes — creates PeriodLog (null flow) or deletes it | Yes — calls `logPeriodDay` or `unLogPeriodDay` |
+| `PeriodToggled` | Yes — creates PeriodLog (null flow), deletes it, or shows unmark confirmation if it has data | Yes — calls `logPeriodDay` or `unLogPeriodDay` (unless data check triggers dialog) |
+| `UnmarkPeriodConfirmed` | Yes — nulls periodLog, clears confirmation flag | Yes — calls `unLogPeriodDay`, auto-saves |
+| `UnmarkPeriodDismissed` | Yes — clears confirmation flag | No |
 | `WaterIncrement` | Yes (optimistic) | Yes — upserts water intake to DB |
 | `SymptomLongPressed` | Yes — sets `symptomForContextMenu` | No |
 | `RenameSymptomConfirmed` | Returns `currentState` | Yes — calls `RenameSymptomUseCase`, updates state on result |
@@ -2183,6 +2196,9 @@ The `ui/components/` package contains shared composables used across multiple sc
 | `LibraryChip` | `ui/log/pages/SymptomsPage.kt` | Chip with tap + long-press support for library items (see below) |
 | `RenameDialog` | `ui/log/pages/SymptomsPage.kt` | AlertDialog with pre-filled OutlinedTextField for renaming library items |
 | `DeleteLibraryItemDialog` | `ui/log/pages/SymptomsPage.kt` | Delete confirmation dialog with log count warning |
+| `UnmarkPeriodDayConfirmationDialog` | `ui/tracker/UnmarkPeriodConfirmationDialog.kt` | Confirmation dialog for removing a single period day with logged data |
+| `UnmarkPeriodRangeConfirmationDialog` | `ui/tracker/UnmarkPeriodConfirmationDialog.kt` | Confirmation dialog for removing multiple period days via drag-shrink |
+| `UnmarkPeriodDayDialog` | `ui/log/UnmarkPeriodDayDialog.kt` | Confirmation dialog for DailyLog period toggle-off with logged data |
 
 These components follow the project convention of one `@Composable` per UI
 responsibility and use `stringResource()` for all user-visible text.
@@ -2607,6 +2623,8 @@ One of the largest files in the codebase. Key sections:
 - **`saveFullLog()`:** Uses delete-then-insert transaction semantics
 - **`logPeriodDay()`:** The 4-scenario state machine (see [section 2.5](#25-use-cases-to-repository-to-dao))
 - **`unLogPeriodDay()`:** The inverse 4-scenario state machine
+- **`getPeriodLogForDate()`:** Fetches a single `PeriodLog` for a date (used by unmark data check)
+- **`getPeriodLogsForDateRange()`:** Batch fetches `PeriodLog`s for a date range (used by drag-shrink data check)
 - **`observeDayDetails()`:** Combines `getAllPeriods()` and `getAllLogs()` into a
   `Map<LocalDate, DayDetails>` — the single source of truth for the calendar UI
 - **`seedDatabaseForDebug()`:** Generates 6 cycles of realistic data (varied cycle

--- a/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/models/PeriodLogTest.kt
+++ b/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/models/PeriodLogTest.kt
@@ -1,0 +1,79 @@
+package com.veleda.cyclewise.domain.models
+
+import com.veleda.cyclewise.testutil.buildPeriodLog
+import kotlin.time.ExperimentalTime
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [PeriodLog.hasData].
+ */
+@OptIn(ExperimentalTime::class)
+class PeriodLogTest {
+
+    @Test
+    fun `hasData WHEN allFieldsNull THEN returnsFalse`() {
+        // GIVEN — a period log with no user-entered data
+        val log = buildPeriodLog(
+            flowIntensity = null,
+            periodColor = null,
+            periodConsistency = null,
+        )
+
+        // THEN
+        assertFalse(log.hasData(), "hasData should be false when all fields are null")
+    }
+
+    @Test
+    fun `hasData WHEN onlyFlowIntensityNonNull THEN returnsTrue`() {
+        // GIVEN
+        val log = buildPeriodLog(
+            flowIntensity = FlowIntensity.MEDIUM,
+            periodColor = null,
+            periodConsistency = null,
+        )
+
+        // THEN
+        assertTrue(log.hasData(), "hasData should be true when flowIntensity is non-null")
+    }
+
+    @Test
+    fun `hasData WHEN onlyPeriodColorNonNull THEN returnsTrue`() {
+        // GIVEN
+        val log = buildPeriodLog(
+            flowIntensity = null,
+            periodColor = PeriodColor.DARK_RED,
+            periodConsistency = null,
+        )
+
+        // THEN
+        assertTrue(log.hasData(), "hasData should be true when periodColor is non-null")
+    }
+
+    @Test
+    fun `hasData WHEN onlyPeriodConsistencyNonNull THEN returnsTrue`() {
+        // GIVEN
+        val log = buildPeriodLog(
+            flowIntensity = null,
+            periodColor = null,
+            periodConsistency = PeriodConsistency.THICK,
+        )
+
+        // THEN
+        assertTrue(log.hasData(), "hasData should be true when periodConsistency is non-null")
+    }
+
+    @Test
+    fun `hasData WHEN multipleFieldsNonNull THEN returnsTrue`() {
+        // GIVEN
+        val log = buildPeriodLog(
+            flowIntensity = FlowIntensity.HEAVY,
+            periodColor = PeriodColor.BRIGHT_RED,
+            periodConsistency = PeriodConsistency.MODERATE,
+        )
+
+        // THEN
+        assertTrue(log.hasData(), "hasData should be true when multiple fields are non-null")
+    }
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/PeriodLog.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/PeriodLog.kt
@@ -27,4 +27,12 @@ data class PeriodLog @OptIn(ExperimentalTime::class) constructor(
     val periodConsistency: PeriodConsistency? = null,
     val createdAt: Instant,
     val updatedAt: Instant
-)
+) {
+    /**
+     * Returns `true` if this log contains any user-entered period detail data
+     * (flow intensity, color, or consistency). A [PeriodLog] can exist with all
+     * fields null when the user toggled "on period" without selecting any details.
+     */
+    fun hasData(): Boolean =
+        flowIntensity != null || periodColor != null || periodConsistency != null
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/repository/PeriodRepository.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/repository/PeriodRepository.kt
@@ -1,6 +1,7 @@
 package com.veleda.cyclewise.domain.repository
 
 import com.veleda.cyclewise.domain.models.Period
+import com.veleda.cyclewise.domain.models.PeriodLog
 import com.veleda.cyclewise.domain.models.DayDetails
 import com.veleda.cyclewise.domain.models.FullDailyLog
 import com.veleda.cyclewise.domain.models.Medication
@@ -112,6 +113,21 @@ interface PeriodRepository {
      * Also deletes any [PeriodLog] for the date.
      */
     suspend fun unLogPeriodDay(date: LocalDate)
+
+    // ── Period Log Lookup ──────────────────────────────────────────────
+
+    /**
+     * Returns the [PeriodLog] for the given [date], or null if no entry or period log
+     * exists for that date. Used to check whether a period day has user-entered data
+     * before unmarking it.
+     */
+    suspend fun getPeriodLogForDate(date: LocalDate): PeriodLog?
+
+    /**
+     * Returns all [PeriodLog]s whose parent daily entries fall within the given date
+     * range (inclusive). Days with no entry or no period log are omitted.
+     */
+    suspend fun getPeriodLogsForDateRange(startDate: LocalDate, endDate: LocalDate): List<PeriodLog>
 
     // ── Daily Log Access ─────────────────────────────────────────────────
 


### PR DESCRIPTION
…ged data (#94)

  When users unmark a period day (via long-press, drag-shrink, or daily
  log toggle), the PeriodLog was hard-deleted immediately with no warning.
  If the user had recorded flow intensity, period color, or consistency
  data, it was permanently lost.

  Add a confirmation dialog that warns users before deleting period days
  that contain user-entered data. Days without data are still unmarked
  silently to preserve the existing UX for the common case.

  Key changes:
  - Add PeriodLog.hasData() as single source of truth for data presence
  - Add repository methods getPeriodLogForDate() and getPeriodLogsForDateRange() to support pre-delete data checks
  - Add PeriodLogDao.getLogsForEntries() batch query to avoid N+1
  - Modify TrackerViewModel PeriodMarkDay/PeriodRangeDragged handlers to check for data before unmarking
  - Modify DailyLogViewModel PeriodToggled(false) handler to check for data before unmarking
  - Create UnmarkPeriodDayConfirmationDialog and UnmarkPeriodRangeConfirmationDialog for TrackerScreen
  - Create UnmarkPeriodDayDialog for DailyLogScreen
  - Add comprehensive unit and Robolectric tests (77 tests, 0 failures)
  - Update detekt baseline for DailyLogViewModel.onEvent complexity growth
  - Update developerOnboarding.md to document new confirmation flows

  Signed-off-by: Daniel Simmons <SmileyBob72801@gmail.com>

---
name: 🚀 Pull Request
about: Propose changes to the RhythmWise codebase

---

### Description

<!-- A clear and concise description of the changes. -->

### Related Issue

<!-- 
Link to the issue that this PR addresses. 
For example: "Closes #23" or "Fixes #12". This will automatically close the issue when the PR is merged.
-->

### Checklist

<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->