### PR TITLE
feat(ui): move phase legend and heatmap selector below calendar grid …

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/TrackerScreen.kt
@@ -347,29 +347,6 @@ fun TrackerScreen(navController: NavController) {
                 days.subList(firstDayOfWeek.value - 1, days.size) + days.subList(0, firstDayOfWeek.value - 1)
             }
             DaysOfWeekTitle(daysOfWeek = daysOfWeek)
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(end = dims.sm)
-                    .coachMarkTarget(HintKey.TRACKER_PHASE_LEGEND, coachMarkState),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                PhaseLegend(
-                    palette = palette,
-                    phaseVisible = phaseVisible,
-                    modifier = Modifier.weight(1f),
-                )
-                InfoButton(
-                    onClick = { viewModel.onEvent(TrackerEvent.ShowEducationalSheet("CyclePhase")) },
-                    contentDescription = stringResource(R.string.educational_info_button_cd, stringResource(R.string.tracker_phase_label)),
-                )
-            }
-
-            HeatmapSelector(
-                selectedMetric = uiState.selectedHeatmapMetric,
-                onMetricSelected = { viewModel.onEvent(TrackerEvent.SelectHeatmapMetric(it)) },
-            )
-
             Box(modifier = Modifier.weight(1f)) {
                 CalendarGrid(
                     uiState = uiState,
@@ -428,6 +405,27 @@ fun TrackerScreen(navController: NavController) {
                     )
                 }
             }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(end = dims.sm)
+                    .coachMarkTarget(HintKey.TRACKER_PHASE_LEGEND, coachMarkState),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                PhaseLegend(
+                    palette = palette,
+                    phaseVisible = phaseVisible,
+                    modifier = Modifier.weight(1f),
+                )
+                InfoButton(
+                    onClick = { viewModel.onEvent(TrackerEvent.ShowEducationalSheet("CyclePhase")) },
+                    contentDescription = stringResource(R.string.educational_info_button_cd, stringResource(R.string.tracker_phase_label)),
+                )
+            }
+            HeatmapSelector(
+                selectedMetric = uiState.selectedHeatmapMetric,
+                onMetricSelected = { viewModel.onEvent(TrackerEvent.SelectHeatmapMetric(it)) },
+            )
         }
         }
 


### PR DESCRIPTION
…(#97)

  Reorder composables in TrackerScreen so the calendar grid sits directly
  beneath the day-of-week headers. The phase legend and heatmap metric
  selector chips now appear below the calendar, following the convention
  of placing legends below data visualizations and eliminating the visual
  gap between headers and date columns.

  Closes #97

  Signed-off-by: Daniel Simmons <SmileyBob72801@gmail.com>

---
name: 🚀 Pull Request
about: Propose changes to the RhythmWise codebase

---

### Description

<!-- A clear and concise description of the changes. -->

### Related Issue

<!-- 
Link to the issue that this PR addresses. 
For example: "Closes #23" or "Fixes #12". This will automatically close the issue when the PR is merged.
-->

### Checklist

<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->