### PR TITLE
feat(ui): make wellness empty-state prompt a one-time experience

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
@@ -357,6 +357,7 @@ val appModule = module {
                 deleteSymptomUseCase = get(),
                 renameMedicationUseCase = get(),
                 deleteMedicationUseCase = get(),
+                hintPreferences = get(),
             )
         }
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/coachmark/CoachMarkDef.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/coachmark/CoachMarkDef.kt
@@ -19,6 +19,9 @@ enum class HintKey {
     DAILY_LOG_MEDICATIONS_TAB,
     DAILY_LOG_NOTES_TAB,
 
+    // Daily Log one-time prompts
+    WELLNESS_EMPTY_PROMPT,
+
     // Tracker walkthrough (7 steps)
     TRACKER_WELCOME,
     TRACKER_NAV,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
@@ -400,6 +400,7 @@ fun DailyLogScreen(
                                 energyLevel = log.entry.energyLevel,
                                 libidoScore = log.entry.libidoScore,
                                 waterCups = uiState.waterCups,
+                                showWellnessPrompt = uiState.showWellnessPrompt,
                                 onMoodChanged = { score ->
                                     viewModel.onEvent(DailyLogEvent.MoodScoreChanged(score))
                                     if (activeHint?.def?.key == HintKey.DAILY_LOG_MOOD) {

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModel.kt
@@ -22,6 +22,8 @@ import com.veleda.cyclewise.domain.usecases.GetOrCreateDailyLogUseCase
 import com.veleda.cyclewise.domain.usecases.RenameMedicationUseCase
 import com.veleda.cyclewise.domain.usecases.RenameResult
 import com.veleda.cyclewise.domain.usecases.RenameSymptomUseCase
+import com.veleda.cyclewise.ui.coachmark.HintKey
+import com.veleda.cyclewise.ui.coachmark.HintPreferences
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -77,6 +79,8 @@ data class DailyLogUiState(
     val medicationDeleteLogCount: Int = 0,
     val renameError: String? = null,
     val showUnmarkPeriodConfirmation: Boolean = false,
+    /** Whether to display the one-time wellness empty-state prompt. */
+    val showWellnessPrompt: Boolean = false,
 )
 
 /**
@@ -117,6 +121,7 @@ class DailyLogViewModel(
     private val deleteSymptomUseCase: DeleteSymptomUseCase,
     private val renameMedicationUseCase: RenameMedicationUseCase,
     private val deleteMedicationUseCase: DeleteMedicationUseCase,
+    private val hintPreferences: HintPreferences,
 ) : ViewModel()
 {
     private val _uiState = MutableStateFlow(DailyLogUiState())
@@ -158,6 +163,10 @@ class DailyLogViewModel(
 
             onEvent(DailyLogEvent.LogLoaded(loadedLog, initialSymptoms, initialMedications))
             _uiState.update { it.copy(waterCups = waterIntake?.cups ?: 0, isPeriodDay = isPeriodDay) }
+
+            val wellnessPromptSeen = hintPreferences
+                .isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT).first()
+            _uiState.update { it.copy(showWellnessPrompt = !wellnessPromptSeen) }
 
             // Persist the backfilled PeriodLog immediately.
             if (isPeriodDay && result.periodLog == null) {
@@ -286,19 +295,8 @@ class DailyLogViewModel(
                 autoSave()
             }
 
-            is DailyLogEvent.WaterIncrement -> viewModelScope.launch {
-                periodRepository.upsertWaterIntake(
-                    WaterIntake(
-                        date = entryDate,
-                        cups = _uiState.value.waterCups,
-                        createdAt = Clock.System.now(),
-                        updatedAt = Clock.System.now()
-                    )
-                )
-            }
-
-            is DailyLogEvent.WaterDecrement -> viewModelScope.launch {
-                if (_uiState.value.waterCups > 0) {
+            is DailyLogEvent.WaterIncrement -> {
+                viewModelScope.launch {
                     periodRepository.upsertWaterIntake(
                         WaterIntake(
                             date = entryDate,
@@ -308,12 +306,34 @@ class DailyLogViewModel(
                         )
                     )
                 }
+                dismissWellnessPromptIfNeeded()
             }
 
-            // Auto-save after state update for data-changing user events.
+            is DailyLogEvent.WaterDecrement -> {
+                viewModelScope.launch {
+                    if (_uiState.value.waterCups > 0) {
+                        periodRepository.upsertWaterIntake(
+                            WaterIntake(
+                                date = entryDate,
+                                cups = _uiState.value.waterCups,
+                                createdAt = Clock.System.now(),
+                                updatedAt = Clock.System.now()
+                            )
+                        )
+                    }
+                }
+                dismissWellnessPromptIfNeeded()
+            }
+
+            // Auto-save for wellness data-changing events (also dismiss prompt).
             is DailyLogEvent.MoodScoreChanged,
             is DailyLogEvent.EnergyLevelChanged,
-            is DailyLogEvent.LibidoScoreChanged,
+            is DailyLogEvent.LibidoScoreChanged -> {
+                autoSave()
+                dismissWellnessPromptIfNeeded()
+            }
+
+            // Auto-save for non-wellness data-changing events.
             is DailyLogEvent.FlowIntensityChanged,
             is DailyLogEvent.PeriodColorChanged,
             is DailyLogEvent.PeriodConsistencyChanged,
@@ -653,6 +673,22 @@ class DailyLogViewModel(
             val currentLog = _uiState.value.log ?: return@launch
             if (!isLogEmpty(currentLog)) {
                 periodRepository.saveFullLog(currentLog)
+            }
+        }
+    }
+
+    /**
+     * Dismisses the one-time wellness empty-state prompt if it is currently showing.
+     *
+     * Called as a side effect when the user first interacts with any wellness metric
+     * (mood, energy, libido, water). Persists the dismissal via [HintPreferences] so
+     * the prompt never reappears.
+     */
+    private fun dismissWellnessPromptIfNeeded() {
+        if (_uiState.value.showWellnessPrompt) {
+            _uiState.update { it.copy(showWellnessPrompt = false) }
+            viewModelScope.launch {
+                hintPreferences.markHintSeen(HintKey.WELLNESS_EMPTY_PROMPT)
             }
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPage.kt
@@ -52,6 +52,9 @@ import com.veleda.cyclewise.ui.theme.RhythmWiseColors
  * @param energyLevel Current energy level (1-5), or `null` if unset.
  * @param libidoScore Current libido score (1-5), or `null` if unset.
  * @param waterCups Current water intake in cups.
+ * @param showWellnessPrompt Whether to display the one-time empty-state prompt.
+ *        Controlled by the ViewModel via [HintPreferences]; once the user logs any
+ *        wellness data, this becomes `false` permanently.
  * @param onMoodChanged Callback when the user selects a mood score.
  * @param onEnergyChanged Callback when the user selects an energy level.
  * @param onLibidoChanged Callback when the user selects a libido score.
@@ -68,6 +71,7 @@ internal fun WellnessPage(
     energyLevel: Int?,
     libidoScore: Int?,
     waterCups: Int,
+    showWellnessPrompt: Boolean = false,
     onMoodChanged: (Int) -> Unit,
     onEnergyChanged: (Int) -> Unit,
     onLibidoChanged: (Int) -> Unit,
@@ -94,11 +98,8 @@ internal fun WellnessPage(
     ) {
         Spacer(Modifier.height(dims.sm))
 
-        val hasNoWellnessData =
-            moodScore == null && energyLevel == null && libidoScore == null && waterCups == 0
-
         AnimatedVisibility(
-            visible = hasNoWellnessData,
+            visible = showWellnessPrompt,
             enter = fadeIn(),
             exit = fadeOut(),
         ) {

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModelTest.kt
@@ -19,6 +19,8 @@ import com.veleda.cyclewise.domain.usecases.GetOrCreateDailyLogUseCase
 import com.veleda.cyclewise.domain.usecases.RenameMedicationUseCase
 import com.veleda.cyclewise.domain.usecases.RenameResult
 import com.veleda.cyclewise.domain.usecases.RenameSymptomUseCase
+import com.veleda.cyclewise.ui.coachmark.HintKey
+import com.veleda.cyclewise.ui.coachmark.HintPreferences
 import com.veleda.cyclewise.testutil.TestData
 import com.veleda.cyclewise.testutil.buildMedication
 import com.veleda.cyclewise.testutil.buildMedicationLog
@@ -70,6 +72,7 @@ class DailyLogViewModelTest {
     private lateinit var mockDeleteSymptomUseCase: DeleteSymptomUseCase
     private lateinit var mockRenameMedicationUseCase: RenameMedicationUseCase
     private lateinit var mockDeleteMedicationUseCase: DeleteMedicationUseCase
+    private lateinit var mockHintPreferences: HintPreferences
 
     private val testDate = TestData.DATE
     private val testInstant = TestData.INSTANT
@@ -98,6 +101,8 @@ class DailyLogViewModelTest {
         mockDeleteSymptomUseCase = mockk(relaxed = true)
         mockRenameMedicationUseCase = mockk(relaxed = true)
         mockDeleteMedicationUseCase = mockk(relaxed = true)
+        mockHintPreferences = mockk(relaxed = true)
+        every { mockHintPreferences.isHintSeen(any()) } returns flowOf(false)
 
         every { mockSymptomProvider.symptoms } returns flowOf(emptyList())
         every { mockMedicationProvider.medications } returns flowOf(emptyList())
@@ -124,6 +129,7 @@ class DailyLogViewModelTest {
             deleteSymptomUseCase = mockDeleteSymptomUseCase,
             renameMedicationUseCase = mockRenameMedicationUseCase,
             deleteMedicationUseCase = mockDeleteMedicationUseCase,
+            hintPreferences = mockHintPreferences,
         )
     }
 
@@ -810,5 +816,98 @@ class DailyLogViewModelTest {
         assertFalse(vm.uiState.value.showUnmarkPeriodConfirmation)
         assertNotNull(vm.uiState.value.log!!.periodLog, "periodLog should be preserved after dismissal")
         coVerify(exactly = 0) { mockRepository.unLogPeriodDay(any()) }
+    }
+
+    // ── Wellness prompt hint tests ────────────────────────────────────
+
+    @Test
+    fun `init WHEN wellnessPromptNotSeen THEN showWellnessPromptTrue`() = runTest {
+        // GIVEN — hint has NOT been seen
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(false)
+
+        // WHEN
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        assertTrue(vm.uiState.value.showWellnessPrompt)
+    }
+
+    @Test
+    fun `init WHEN wellnessPromptAlreadySeen THEN showWellnessPromptFalse`() = runTest {
+        // GIVEN — hint HAS been seen
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(true)
+
+        // WHEN
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // THEN
+        assertFalse(vm.uiState.value.showWellnessPrompt)
+    }
+
+    @Test
+    fun `onEvent MoodScoreChanged WHEN promptShowing THEN dismissesPromptAndMarksHintSeen`() = runTest {
+        // GIVEN — prompt is showing
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(false)
+        val vm = createViewModel()
+        advanceUntilIdle()
+        assertTrue(vm.uiState.value.showWellnessPrompt)
+
+        // WHEN
+        vm.onEvent(DailyLogEvent.MoodScoreChanged(score = 4))
+        advanceUntilIdle()
+
+        // THEN
+        assertFalse(vm.uiState.value.showWellnessPrompt)
+        coVerify(exactly = 1) { mockHintPreferences.markHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) }
+    }
+
+    @Test
+    fun `onEvent EnergyLevelChanged WHEN promptShowing THEN dismissesPrompt`() = runTest {
+        // GIVEN
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(false)
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        vm.onEvent(DailyLogEvent.EnergyLevelChanged(level = 3))
+        advanceUntilIdle()
+
+        // THEN
+        assertFalse(vm.uiState.value.showWellnessPrompt)
+        coVerify(exactly = 1) { mockHintPreferences.markHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) }
+    }
+
+    @Test
+    fun `onEvent WaterIncrement WHEN promptShowing THEN dismissesPrompt`() = runTest {
+        // GIVEN
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(false)
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN
+        vm.onEvent(DailyLogEvent.WaterIncrement)
+        advanceUntilIdle()
+
+        // THEN
+        assertFalse(vm.uiState.value.showWellnessPrompt)
+        coVerify(exactly = 1) { mockHintPreferences.markHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) }
+    }
+
+    @Test
+    fun `onEvent MoodScoreChanged WHEN promptAlreadyDismissed THEN doesNotCallMarkHintSeenAgain`() = runTest {
+        // GIVEN — prompt already seen
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(true)
+        val vm = createViewModel()
+        advanceUntilIdle()
+        assertFalse(vm.uiState.value.showWellnessPrompt)
+
+        // WHEN
+        vm.onEvent(DailyLogEvent.MoodScoreChanged(score = 3))
+        advanceUntilIdle()
+
+        // THEN — markHintSeen should NOT be called
+        coVerify(exactly = 0) { mockHintPreferences.markHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) }
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageEmptyStateTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageEmptyStateTest.kt
@@ -14,6 +14,8 @@ import com.veleda.cyclewise.domain.usecases.GetOrCreateDailyLogUseCase
 import com.veleda.cyclewise.domain.usecases.RenameMedicationUseCase
 import com.veleda.cyclewise.domain.usecases.RenameSymptomUseCase
 import com.veleda.cyclewise.testutil.TestData
+import com.veleda.cyclewise.ui.coachmark.HintKey
+import com.veleda.cyclewise.ui.coachmark.HintPreferences
 import com.veleda.cyclewise.ui.log.DailyLogEvent
 import com.veleda.cyclewise.ui.log.DailyLogViewModel
 import io.mockk.coEvery
@@ -34,8 +36,9 @@ import kotlin.test.*
 /**
  * Tests the conditions that drive the WellnessPage empty-state prompt visibility.
  *
- * The prompt is visible when `moodScore == null && energyLevel == null &&
- * libidoScore == null && waterCups == 0` and hidden otherwise.
+ * The prompt is controlled by a one-time [HintKey.WELLNESS_EMPTY_PROMPT] flag
+ * persisted via [HintPreferences]. It shows only if the user has never logged
+ * wellness data, and is permanently dismissed on the first wellness interaction.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class WellnessPageEmptyStateTest {
@@ -50,6 +53,7 @@ class WellnessPageEmptyStateTest {
     private lateinit var mockSymptomProvider: SymptomLibraryProvider
     private lateinit var mockMedicationProvider: MedicationLibraryProvider
     private lateinit var mockEducationalContentProvider: EducationalContentProvider
+    private lateinit var mockHintPreferences: HintPreferences
 
     private val testDate = TestData.DATE
     private val testInstant = TestData.INSTANT
@@ -77,6 +81,8 @@ class WellnessPageEmptyStateTest {
         mockSymptomProvider = mockk(relaxed = true)
         mockMedicationProvider = mockk(relaxed = true)
         mockEducationalContentProvider = mockk(relaxed = true)
+        mockHintPreferences = mockk(relaxed = true)
+        every { mockHintPreferences.isHintSeen(any()) } returns flowOf(false)
 
         every { mockSymptomProvider.symptoms } returns flowOf(emptyList())
         every { mockMedicationProvider.medications } returns flowOf(emptyList())
@@ -103,72 +109,65 @@ class WellnessPageEmptyStateTest {
             deleteSymptomUseCase = mockk(relaxed = true),
             renameMedicationUseCase = mockk(relaxed = true),
             deleteMedicationUseCase = mockk(relaxed = true),
+            hintPreferences = mockHintPreferences,
         )
     }
 
     @Test
-    fun `empty state visible WHEN all wellness fields are unset`() = runTest {
-        // GIVEN — daily log has no mood, energy, libido, and zero water
+    fun `showWellnessPrompt true WHEN hint not seen`() = runTest {
+        // GIVEN — hint has NOT been seen
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(false)
+
+        // WHEN
         val vm = createViewModel()
         advanceUntilIdle()
 
-        val state = vm.uiState.value
-
-        // THEN — all fields that drive empty-state visibility are in their "empty" state
-        assertNull(state.log?.entry?.moodScore, "moodScore should be null")
-        assertNull(state.log?.entry?.energyLevel, "energyLevel should be null")
-        assertNull(state.log?.entry?.libidoScore, "libidoScore should be null")
-        assertEquals(0, state.waterCups, "waterCups should be 0")
+        // THEN
+        assertTrue(vm.uiState.value.showWellnessPrompt, "prompt should show when hint not seen")
     }
 
     @Test
-    fun `empty state hidden WHEN mood is set`() = runTest {
-        // GIVEN — daily log with mood already set
-        val entryWithMood = emptyEntry.copy(moodScore = 3)
-        val logWithMood = FullDailyLog(entry = entryWithMood)
-        coEvery { mockGetOrCreateDailyLog(any()) } returns logWithMood
+    fun `showWellnessPrompt false WHEN hint already seen`() = runTest {
+        // GIVEN — hint HAS been seen
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(true)
 
-        // WHEN — ViewModel is created
+        // WHEN
         val vm = createViewModel()
         advanceUntilIdle()
 
-        val state = vm.uiState.value
-
-        // THEN — moodScore is non-null, so the empty state condition is false
-        assertNotNull(state.log?.entry?.moodScore, "moodScore should be set")
-        assertEquals(3, state.log?.entry?.moodScore)
+        // THEN
+        assertFalse(vm.uiState.value.showWellnessPrompt, "prompt should hide when hint already seen")
     }
 
     @Test
-    fun `empty state hidden WHEN mood changed via event`() = runTest {
-        // GIVEN — ViewModel starts with empty wellness data
+    fun `showWellnessPrompt dismissed WHEN mood changed via event`() = runTest {
+        // GIVEN — prompt is showing
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(false)
         val vm = createViewModel()
         advanceUntilIdle()
-
-        // Pre-condition: all wellness fields empty
-        assertNull(vm.uiState.value.log?.entry?.moodScore)
+        assertTrue(vm.uiState.value.showWellnessPrompt)
 
         // WHEN — user changes mood score
         vm.onEvent(DailyLogEvent.MoodScoreChanged(4))
         advanceUntilIdle()
 
-        // THEN — moodScore is now set, breaking the empty-state condition
-        val state = vm.uiState.value
-        assertEquals(4, state.log?.entry?.moodScore, "moodScore should be 4 after change")
+        // THEN — prompt is dismissed
+        assertFalse(vm.uiState.value.showWellnessPrompt, "prompt should be dismissed after mood change")
     }
 
     @Test
-    fun `empty state hidden WHEN water incremented`() = runTest {
-        // GIVEN — ViewModel starts with zero water
+    fun `showWellnessPrompt dismissed WHEN water incremented`() = runTest {
+        // GIVEN — prompt is showing
+        every { mockHintPreferences.isHintSeen(HintKey.WELLNESS_EMPTY_PROMPT) } returns flowOf(false)
         val vm = createViewModel()
         advanceUntilIdle()
-        assertEquals(0, vm.uiState.value.waterCups)
+        assertTrue(vm.uiState.value.showWellnessPrompt)
 
         // WHEN — user increments water
         vm.onEvent(DailyLogEvent.WaterIncrement)
         advanceUntilIdle()
 
-        // THEN — waterCups > 0, breaking the empty-state condition
-        assertEquals(1, vm.uiState.value.waterCups, "waterCups should be 1 after increment")
+        // THEN — prompt is dismissed
+        assertFalse(vm.uiState.value.showWellnessPrompt, "prompt should be dismissed after water increment")
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageTest.kt
@@ -38,6 +38,7 @@ class WellnessPageTest {
         energyLevel: Int? = null,
         libidoScore: Int? = null,
         waterCups: Int = 0,
+        showWellnessPrompt: Boolean = false,
         onMoodChanged: (Int) -> Unit = {},
         onEnergyChanged: (Int) -> Unit = {},
         onLibidoChanged: (Int) -> Unit = {},
@@ -54,6 +55,7 @@ class WellnessPageTest {
                         energyLevel = energyLevel,
                         libidoScore = libidoScore,
                         waterCups = waterCups,
+                        showWellnessPrompt = showWellnessPrompt,
                         onMoodChanged = onMoodChanged,
                         onEnergyChanged = onEnergyChanged,
                         onLibidoChanged = onLibidoChanged,
@@ -70,9 +72,9 @@ class WellnessPageTest {
     // region Empty state
 
     @Test
-    fun emptyState_WHEN_allValuesUnset_THEN_promptIsDisplayed() {
-        // Given / When — all defaults (null/0)
-        setContent()
+    fun emptyState_WHEN_showWellnessPromptTrue_THEN_promptIsDisplayed() {
+        // Given / When
+        setContent(showWellnessPrompt = true)
 
         // Then
         composeTestRule.onNodeWithText("Start by rating", substring = true, ignoreCase = true)
@@ -80,19 +82,9 @@ class WellnessPageTest {
     }
 
     @Test
-    fun emptyState_WHEN_moodIsSet_THEN_promptIsHidden() {
-        // Given / When
-        setContent(moodScore = 3)
-
-        // Then
-        composeTestRule.onNodeWithText("Start by rating", substring = true, ignoreCase = true)
-            .assertDoesNotExist()
-    }
-
-    @Test
-    fun emptyState_WHEN_waterIsPositive_THEN_promptIsHidden() {
-        // Given / When
-        setContent(waterCups = 1)
+    fun emptyState_WHEN_showWellnessPromptFalse_THEN_promptIsHidden() {
+        // Given / When — even with all values unset, prompt is hidden when flag is false
+        setContent(showWellnessPrompt = false)
 
         // Then
         composeTestRule.onNodeWithText("Start by rating", substring = true, ignoreCase = true)


### PR DESCRIPTION
  The "Start by rating your mood or energy" instruction text on the
  WellnessPage previously showed and hid reactively based on whether the
  current day had wellness data, causing layout jumps and accidental
  mis-clicks. The prompt is now controlled by a persisted HintPreferences
  flag (WELLNESS_EMPTY_PROMPT) that is permanently dismissed after the
  user's first wellness data interaction (mood, energy, libido, or water).

### Checklist

<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->