### PR TITLE
  feat(log): allow deselection of mood, energy, and libido star ratings

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogEvent.kt
@@ -24,14 +24,14 @@ sealed interface DailyLogEvent {
     /** The user changed the flow intensity for this day's period log. */
     data class FlowIntensityChanged(val intensity: FlowIntensity?) : DailyLogEvent
 
-    /** The user changed the mood score (1-5 scale). */
-    data class MoodScoreChanged(val score: Int) : DailyLogEvent
+    /** The user changed the mood score (1-5 scale), or `null` to clear. */
+    data class MoodScoreChanged(val score: Int?) : DailyLogEvent
 
-    /** The user changed the energy level (1-5 scale). */
-    data class EnergyLevelChanged(val level: Int) : DailyLogEvent
+    /** The user changed the energy level (1-5 scale), or `null` to clear. */
+    data class EnergyLevelChanged(val level: Int?) : DailyLogEvent
 
-    /** The user changed the libido score (1-5 scale). */
-    data class LibidoScoreChanged(val score: Int) : DailyLogEvent
+    /** The user changed the libido score (1-5 scale), or `null` to clear. */
+    data class LibidoScoreChanged(val score: Int?) : DailyLogEvent
 
     /** The user changed the period blood color for this day's period log. */
     data class PeriodColorChanged(val color: PeriodColor?) : DailyLogEvent

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPage.kt
@@ -55,9 +55,9 @@ import com.veleda.cyclewise.ui.theme.RhythmWiseColors
  * @param showWellnessPrompt Whether to display the one-time empty-state prompt.
  *        Controlled by the ViewModel via [HintPreferences]; once the user logs any
  *        wellness data, this becomes `false` permanently.
- * @param onMoodChanged Callback when the user selects a mood score.
- * @param onEnergyChanged Callback when the user selects an energy level.
- * @param onLibidoChanged Callback when the user selects a libido score.
+ * @param onMoodChanged Callback when the user selects or deselects a mood score.
+ * @param onEnergyChanged Callback when the user selects or deselects an energy level.
+ * @param onLibidoChanged Callback when the user selects or deselects a libido score.
  * @param onWaterIncrement Callback when the user taps the water increment button.
  * @param onWaterDecrement Callback when the user taps the water decrement button.
  * @param onShowEducationalSheet Callback to display educational content for the given tag.
@@ -72,9 +72,9 @@ internal fun WellnessPage(
     libidoScore: Int?,
     waterCups: Int,
     showWellnessPrompt: Boolean = false,
-    onMoodChanged: (Int) -> Unit,
-    onEnergyChanged: (Int) -> Unit,
-    onLibidoChanged: (Int) -> Unit,
+    onMoodChanged: (Int?) -> Unit,
+    onEnergyChanged: (Int?) -> Unit,
+    onLibidoChanged: (Int?) -> Unit,
     onWaterIncrement: () -> Unit,
     onWaterDecrement: () -> Unit,
     onShowEducationalSheet: (String) -> Unit,
@@ -204,15 +204,16 @@ internal fun WellnessPage(
  *
  * Renders a row of star icons; filled stars indicate the selected score,
  * outlined stars indicate unselected values. Tapping a star sets that score.
+ * Tapping the already-selected star clears the rating back to `null`.
  *
  * @param selectedMood Currently selected mood score (1-5), or `null` if unset.
- * @param onSelectionChanged Callback invoked with the tapped score.
+ * @param onSelectionChanged Callback invoked with the tapped score, or `null` when deselecting.
  * @param enabled Whether the selector is interactive. When `false`, taps are ignored.
  */
 @Composable
 internal fun MoodSelector(
     selectedMood: Int?,
-    onSelectionChanged: (Int) -> Unit,
+    onSelectionChanged: (Int?) -> Unit,
     enabled: Boolean = true,
 ) {
     Row(
@@ -221,7 +222,7 @@ internal fun MoodSelector(
     ) {
         (1..5).forEach { score ->
             IconButton(
-                onClick = { onSelectionChanged(score) },
+                onClick = { onSelectionChanged(if (score == selectedMood) null else score) },
                 enabled = enabled,
             ) {
                 val icon = if (score <= (selectedMood ?: 0)) Icons.Filled.Star else Icons.Outlined.StarOutlined
@@ -242,15 +243,17 @@ internal fun MoodSelector(
 /**
  * Reusable 1-5 star rating selector for numeric wellness scores (energy, libido).
  *
+ * Tapping the already-selected star clears the rating back to `null`.
+ *
  * @param selectedScore Currently selected score (1-5), or null if unset.
- * @param onSelectionChanged Callback invoked when the user taps a score.
+ * @param onSelectionChanged Callback invoked with the tapped score, or `null` when deselecting.
  * @param contentDescriptionPrefix Prefix for accessibility labels (e.g., "Energy").
  * @param enabled Whether the selector is interactive. When `false`, taps are ignored.
  */
 @Composable
 internal fun ScoreSelector(
     selectedScore: Int?,
-    onSelectionChanged: (Int) -> Unit,
+    onSelectionChanged: (Int?) -> Unit,
     contentDescriptionPrefix: String,
     enabled: Boolean = true,
 ) {
@@ -260,7 +263,7 @@ internal fun ScoreSelector(
     ) {
         (1..5).forEach { score ->
             IconButton(
-                onClick = { onSelectionChanged(score) },
+                onClick = { onSelectionChanged(if (score == selectedScore) null else score) },
                 enabled = enabled,
             ) {
                 val icon = if (score <= (selectedScore ?: 0)) Icons.Filled.Star else Icons.Outlined.StarOutlined

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/DailyLogViewModelTest.kt
@@ -349,6 +349,74 @@ class DailyLogViewModelTest {
     }
 
     @Test
+    fun `onEvent MoodScoreChanged null THEN setsScoreToNull`() = runTest {
+        // GIVEN — ViewModel with a loaded log that has a mood score
+        val vm = createViewModel()
+        advanceUntilIdle()
+        vm.onEvent(DailyLogEvent.MoodScoreChanged(score = 4))
+        advanceUntilIdle()
+        assertEquals(4, vm.uiState.value.log?.entry?.moodScore)
+
+        // WHEN — mood is deselected
+        vm.onEvent(DailyLogEvent.MoodScoreChanged(score = null))
+        advanceUntilIdle()
+
+        // THEN — mood score is null
+        assertNull(vm.uiState.value.log?.entry?.moodScore)
+    }
+
+    @Test
+    fun `onEvent EnergyLevelChanged null THEN setsLevelToNull`() = runTest {
+        // GIVEN
+        val vm = createViewModel()
+        advanceUntilIdle()
+        vm.onEvent(DailyLogEvent.EnergyLevelChanged(level = 3))
+        advanceUntilIdle()
+        assertEquals(3, vm.uiState.value.log?.entry?.energyLevel)
+
+        // WHEN — energy is deselected
+        vm.onEvent(DailyLogEvent.EnergyLevelChanged(level = null))
+        advanceUntilIdle()
+
+        // THEN
+        assertNull(vm.uiState.value.log?.entry?.energyLevel)
+    }
+
+    @Test
+    fun `onEvent LibidoScoreChanged null THEN setsScoreToNull`() = runTest {
+        // GIVEN
+        val vm = createViewModel()
+        advanceUntilIdle()
+        vm.onEvent(DailyLogEvent.LibidoScoreChanged(score = 2))
+        advanceUntilIdle()
+        assertEquals(2, vm.uiState.value.log?.entry?.libidoScore)
+
+        // WHEN — libido is deselected
+        vm.onEvent(DailyLogEvent.LibidoScoreChanged(score = null))
+        advanceUntilIdle()
+
+        // THEN
+        assertNull(vm.uiState.value.log?.entry?.libidoScore)
+    }
+
+    @Test
+    fun `onEvent MoodScoreChanged null THEN autoSavesLog`() = runTest {
+        // GIVEN — ViewModel with a loaded log that has other data (energy set)
+        val vm = createViewModel()
+        advanceUntilIdle()
+        assertNotNull(vm.uiState.value.log)
+        vm.onEvent(DailyLogEvent.EnergyLevelChanged(level = 3))
+        advanceUntilIdle()
+
+        // WHEN — mood is deselected (log is non-empty because energy is set)
+        vm.onEvent(DailyLogEvent.MoodScoreChanged(score = null))
+        advanceUntilIdle()
+
+        // THEN — saveFullLog is called (auto-save persists null)
+        coVerify(atLeast = 2) { mockRepository.saveFullLog(any()) }
+    }
+
+    @Test
     fun `onEvent NoteChanged THEN debouncesAutoSave`() = runTest {
         // GIVEN — ViewModel with a loaded log
         val vm = createViewModel()

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageTest.kt
@@ -39,9 +39,9 @@ class WellnessPageTest {
         libidoScore: Int? = null,
         waterCups: Int = 0,
         showWellnessPrompt: Boolean = false,
-        onMoodChanged: (Int) -> Unit = {},
-        onEnergyChanged: (Int) -> Unit = {},
-        onLibidoChanged: (Int) -> Unit = {},
+        onMoodChanged: (Int?) -> Unit = {},
+        onEnergyChanged: (Int?) -> Unit = {},
+        onLibidoChanged: (Int?) -> Unit = {},
         onWaterIncrement: () -> Unit = {},
         onWaterDecrement: () -> Unit = {},
         onShowEducationalSheet: (String) -> Unit = {},
@@ -287,6 +287,67 @@ class WellnessPageTest {
 
         // Then — callback fires (star is enabled)
         assert(captured == 3) { "Expected mood score 3, got $captured" }
+    }
+
+    // endregion
+
+    // region Deselection (toggle) behavior
+
+    @Test
+    fun moodSelector_WHEN_selectedStarTapped_THEN_invokesCallbackWithNull() {
+        // Given — mood is already set to 3
+        var captured: Int? = 3
+        setContent(moodScore = 3, onMoodChanged = { captured = it })
+
+        // When — tap the same star (3)
+        composeTestRule.onAllNodesWithContentDescription("Mood score 3")[0]
+            .performClick()
+
+        // Then — callback receives null (deselect)
+        assert(captured == null) { "Expected null (deselect), got $captured" }
+    }
+
+    @Test
+    fun moodSelector_WHEN_differentStarTapped_THEN_invokesCallbackWithNewScore() {
+        // Given — mood is already set to 3
+        var captured: Int? = null
+        setContent(moodScore = 3, onMoodChanged = { captured = it })
+
+        // When — tap a different star (5)
+        composeTestRule.onAllNodesWithContentDescription("Mood score 5")[0]
+            .performClick()
+
+        // Then — callback receives 5 (change selection)
+        assert(captured == 5) { "Expected 5, got $captured" }
+    }
+
+    @Test
+    fun energySelector_WHEN_selectedStarTapped_THEN_invokesCallbackWithNull() {
+        // Given — energy is already set to 2
+        var captured: Int? = 2
+        setContent(energyLevel = 2, onEnergyChanged = { captured = it })
+
+        // When — tap the same star (2)
+        composeTestRule.onAllNodesWithContentDescription("Energy score 2")[0]
+            .performClick()
+
+        // Then
+        assert(captured == null) { "Expected null (deselect), got $captured" }
+    }
+
+    @Test
+    fun libidoSelector_WHEN_selectedStarTapped_THEN_invokesCallbackWithNull() {
+        // Given — libido is already set to 1
+        var captured: Int? = 1
+        setContent(libidoScore = 1, onLibidoChanged = { captured = it })
+
+        // When — tap the same star (1); libido section may need scrolling
+        composeTestRule.onAllNodesWithContentDescription("Libido score 1")[0]
+            .performScrollTo()
+            .performClick()
+
+        // Then
+        assert(captured == null) { "Expected null (deselect), got $captured" }
     }
 
     // endregion


### PR DESCRIPTION
---
name: 🚀 Pull Request
about: Propose changes to the RhythmWise codebase

---

### Description

Tapping the already-selected star in the mood, energy, or libido rating selectors now clears the rating back to null (unlogged). This implements the standard toggle pattern where the same star acts as both select and deselect.

### Related Issue

  Closes #111

### Checklist

<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->