### PR TITLE
  feat(log): add "Done" navigation button and tab completion tinting …

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/CycleWiseAppUI.kt
@@ -158,6 +158,13 @@ fun CycleWiseAppUI() {
                                 restoreState = true
                             }
                         },
+                        onDone = {
+                            navController.navigate(NavRoute.Tracker.route) {
+                                popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                launchSingleTop = true
+                                restoreState = true
+                            }
+                        },
                     )
                 }
                 composable(NavRoute.Tracker.route) {
@@ -194,6 +201,7 @@ fun CycleWiseAppUI() {
                     if (dateString != null) {
                         DailyLogScreen(
                             date = LocalDate.parse(dateString),
+                            onDone = { navController.popBackStack() },
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/DailyLogScreen.kt
@@ -1,6 +1,9 @@
 package com.veleda.cyclewise.ui.log
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -27,8 +30,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.veleda.cyclewise.R
@@ -92,12 +97,15 @@ private const val TAB_ROW_SETTLE_MS = 500L
  * @param date The calendar date whose daily log is being viewed/edited.
  * @param onNavigateToTracker Callback invoked when the walkthrough completes and the
  *        user should be navigated to the Tracker screen for its walkthrough.
+ * @param onDone Callback invoked when the user taps the "Done" button on any tab page
+ *        to return to the Tracker screen.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun DailyLogScreen(
     date: LocalDate,
     onNavigateToTracker: () -> Unit = {},
+    onDone: () -> Unit = {},
 ) {
     val dims = LocalDimensions.current
     val koin = getKoin()
@@ -326,6 +334,25 @@ fun DailyLogScreen(
                             .coachMarkTarget(HintKey.DAILY_LOG_EXPLORE_TABS, coachMarkState),
                     ) {
                         pageLabels.forEachIndexed { index, label ->
+                            val tabHasData = when (index) {
+                                PAGE_WELLNESS -> log.entry.moodScore != null ||
+                                        log.entry.energyLevel != null ||
+                                        log.entry.libidoScore != null ||
+                                        uiState.waterCups > 0
+                                PAGE_PERIOD -> uiState.isPeriodDay
+                                PAGE_SYMPTOMS -> log.symptomLogs.isNotEmpty()
+                                PAGE_MEDICATIONS -> log.medicationLogs.isNotEmpty()
+                                PAGE_NOTES -> log.entry.customTags.isNotEmpty() ||
+                                        !log.entry.note.isNullOrBlank()
+                                else -> false
+                            }
+                            val tintColor by animateColorAsState(
+                                targetValue = if (tabHasData)
+                                    MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f)
+                                else Color.Transparent,
+                                animationSpec = tween(300),
+                                label = "tabTint_$index",
+                            )
                             Tab(
                                 selected = pagerState.currentPage == index,
                                 onClick = {
@@ -366,22 +393,26 @@ fun DailyLogScreen(
                                         style = MaterialTheme.typography.labelLarge,
                                     )
                                 },
-                                modifier = when (index) {
-                                    PAGE_PERIOD -> Modifier.coachMarkTarget(HintKey.DAILY_LOG_PERIOD_TAB, coachMarkState)
-                                    PAGE_SYMPTOMS -> Modifier.coachMarkTarget(
-                                        HintKey.DAILY_LOG_SYMPTOMS_TAB, coachMarkState,
-                                        enabled = pagerState.currentPage == PAGE_SYMPTOMS,
-                                    )
-                                    PAGE_MEDICATIONS -> Modifier.coachMarkTarget(
-                                        HintKey.DAILY_LOG_MEDICATIONS_TAB, coachMarkState,
-                                        enabled = pagerState.currentPage == PAGE_MEDICATIONS,
-                                    )
-                                    PAGE_NOTES -> Modifier.coachMarkTarget(
-                                        HintKey.DAILY_LOG_NOTES_TAB, coachMarkState,
-                                        enabled = pagerState.currentPage == PAGE_NOTES,
-                                    )
-                                    else -> Modifier
-                                },
+                                modifier = Modifier
+                                    .background(tintColor, RoundedCornerShape(dims.sm))
+                                    .then(
+                                        when (index) {
+                                            PAGE_PERIOD -> Modifier.coachMarkTarget(HintKey.DAILY_LOG_PERIOD_TAB, coachMarkState)
+                                            PAGE_SYMPTOMS -> Modifier.coachMarkTarget(
+                                                HintKey.DAILY_LOG_SYMPTOMS_TAB, coachMarkState,
+                                                enabled = pagerState.currentPage == PAGE_SYMPTOMS,
+                                            )
+                                            PAGE_MEDICATIONS -> Modifier.coachMarkTarget(
+                                                HintKey.DAILY_LOG_MEDICATIONS_TAB, coachMarkState,
+                                                enabled = pagerState.currentPage == PAGE_MEDICATIONS,
+                                            )
+                                            PAGE_NOTES -> Modifier.coachMarkTarget(
+                                                HintKey.DAILY_LOG_NOTES_TAB, coachMarkState,
+                                                enabled = pagerState.currentPage == PAGE_NOTES,
+                                            )
+                                            else -> Modifier
+                                        }
+                                    ),
                             )
                         }
                     }
@@ -421,6 +452,7 @@ fun DailyLogScreen(
                                     }
                                 },
                                 onWaterDecrement = { viewModel.onEvent(DailyLogEvent.WaterDecrement) },
+                                onDone = onDone,
                                 onShowEducationalSheet = { tag -> viewModel.onEvent(DailyLogEvent.ShowEducationalSheet(tag)) },
                                 coachMarkState = coachMarkState,
                                 activeHintKey = activeHint?.def?.key,
@@ -439,6 +471,7 @@ fun DailyLogScreen(
                                 onFlowChanged = { viewModel.onEvent(DailyLogEvent.FlowIntensityChanged(it)) },
                                 onColorChanged = { viewModel.onEvent(DailyLogEvent.PeriodColorChanged(it)) },
                                 onConsistencyChanged = { viewModel.onEvent(DailyLogEvent.PeriodConsistencyChanged(it)) },
+                                onDone = onDone,
                                 onShowEducationalSheet = { tag -> viewModel.onEvent(DailyLogEvent.ShowEducationalSheet(tag)) },
                                 coachMarkState = coachMarkState,
                                 activeHintKey = activeHint?.def?.key,
@@ -449,6 +482,7 @@ fun DailyLogScreen(
                                 onToggleSymptom = { viewModel.onEvent(DailyLogEvent.SymptomToggled(it)) },
                                 onCreateAndAddSymptom = { viewModel.onEvent(DailyLogEvent.CreateAndAddSymptom(it)) },
                                 onShowEducationalSheet = { tag -> viewModel.onEvent(DailyLogEvent.ShowEducationalSheet(tag)) },
+                                onDone = onDone,
                                 symptomForContextMenu = uiState.symptomForContextMenu,
                                 symptomRenaming = uiState.symptomRenaming,
                                 symptomToDelete = uiState.symptomToDelete,
@@ -467,6 +501,7 @@ fun DailyLogScreen(
                                 onToggleMedication = { viewModel.onEvent(DailyLogEvent.MedicationToggled(it)) },
                                 onCreateAndAddMedication = { viewModel.onEvent(DailyLogEvent.MedicationCreatedAndAdded(it)) },
                                 onShowEducationalSheet = { tag -> viewModel.onEvent(DailyLogEvent.ShowEducationalSheet(tag)) },
+                                onDone = onDone,
                                 medicationForContextMenu = uiState.medicationForContextMenu,
                                 medicationRenaming = uiState.medicationRenaming,
                                 medicationToDelete = uiState.medicationToDelete,
@@ -485,6 +520,7 @@ fun DailyLogScreen(
                                 onAddTag = { viewModel.onEvent(DailyLogEvent.TagAdded(it)) },
                                 onRemoveTag = { viewModel.onEvent(DailyLogEvent.TagRemoved(it)) },
                                 onNoteChanged = { viewModel.onEvent(DailyLogEvent.NoteChanged(it)) },
+                                onDone = onDone,
                             )
                         }
                     }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/MedicationsPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/MedicationsPage.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.MedicalServices
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -56,6 +57,7 @@ import com.veleda.cyclewise.ui.theme.LocalDimensions
  * @param onToggleMedication         Callback when the user toggles a medication chip.
  * @param onCreateAndAddMedication   Callback when the user creates and logs a new medication by name.
  * @param onShowEducationalSheet     Callback to display educational content for the given tag.
+ * @param onDone                     Callback when the user taps the "Done" button to return to the Tracker.
  * @param medicationForContextMenu   Medication whose context menu is currently shown, or null.
  * @param medicationRenaming         Medication currently being renamed (dialog open), or null.
  * @param medicationToDelete         Medication pending deletion confirmation, or null.
@@ -75,6 +77,7 @@ internal fun MedicationsPage(
     onToggleMedication: (Medication) -> Unit,
     onCreateAndAddMedication: (String) -> Unit,
     onShowEducationalSheet: (String) -> Unit,
+    onDone: () -> Unit = {},
     medicationForContextMenu: Medication? = null,
     medicationRenaming: Medication? = null,
     medicationToDelete: Medication? = null,
@@ -123,6 +126,13 @@ internal fun MedicationsPage(
                 onDeleteClicked = onDeleteClicked,
                 onEditDismissed = onEditDismissed,
             )
+        }
+
+        FilledTonalButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.daily_log_done_button))
         }
 
         Spacer(Modifier.height(dims.xl))

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/NotesTagsPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/NotesTagsPage.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.automirrored.outlined.Notes
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
@@ -54,6 +55,7 @@ import com.veleda.cyclewise.ui.theme.LocalDimensions
  * @param onAddTag Callback when the user adds a new tag.
  * @param onRemoveTag Callback when the user removes an existing tag.
  * @param onNoteChanged Callback when the note text changes.
+ * @param onDone Callback when the user taps the "Done" button to return to the Tracker.
  */
 @Composable
 internal fun NotesTagsPage(
@@ -62,6 +64,7 @@ internal fun NotesTagsPage(
     onAddTag: (String) -> Unit,
     onRemoveTag: (String) -> Unit,
     onNoteChanged: (String) -> Unit,
+    onDone: () -> Unit = {},
 ) {
     val dims = LocalDimensions.current
     var showHelp by remember { mutableStateOf(false) }
@@ -94,6 +97,13 @@ internal fun NotesTagsPage(
                 note = note,
                 onNoteChanged = onNoteChanged,
             )
+        }
+
+        FilledTonalButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.daily_log_done_button))
         }
 
         Spacer(Modifier.height(dims.xl))

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/PeriodPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/PeriodPage.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.outlined.WaterDrop
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
@@ -58,6 +59,7 @@ import com.veleda.cyclewise.ui.theme.LocalDimensions
  * @param onFlowChanged Callback when the user selects a flow intensity (or `null` to deselect).
  * @param onColorChanged Callback when the user selects a period color (or `null` to deselect).
  * @param onConsistencyChanged Callback when the user selects a consistency (or `null` to deselect).
+ * @param onDone Callback when the user taps the "Done" button to return to the Tracker.
  * @param onShowEducationalSheet Callback to display educational content for the given tag.
  * @param coachMarkState Optional coach-mark state for walkthrough integration.
  * @param activeHintKey The currently active walkthrough hint key, or `null` when no
@@ -73,6 +75,7 @@ internal fun PeriodPage(
     onFlowChanged: (FlowIntensity?) -> Unit,
     onColorChanged: (PeriodColor?) -> Unit,
     onConsistencyChanged: (PeriodConsistency?) -> Unit,
+    onDone: () -> Unit = {},
     onShowEducationalSheet: (String) -> Unit,
     coachMarkState: CoachMarkState? = null,
     activeHintKey: HintKey? = null,
@@ -178,6 +181,13 @@ internal fun PeriodPage(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+        }
+
+        FilledTonalButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.daily_log_done_button))
         }
 
         Spacer(Modifier.height(dims.xl))

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/SymptomsPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/SymptomsPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.outlined.LocalHospital
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -78,6 +79,7 @@ import com.veleda.cyclewise.ui.theme.LocalDimensions
  * @param onToggleSymptom          Callback when the user toggles a symptom chip.
  * @param onCreateAndAddSymptom    Callback when the user creates and logs a new symptom by name.
  * @param onShowEducationalSheet   Callback to display educational content for the given tag.
+ * @param onDone                   Callback when the user taps the "Done" button to return to the Tracker.
  * @param symptomForContextMenu    Symptom whose context menu is currently shown, or null.
  * @param symptomRenaming          Symptom currently being renamed (dialog open), or null.
  * @param symptomToDelete          Symptom pending deletion confirmation, or null.
@@ -97,6 +99,7 @@ internal fun SymptomsPage(
     onToggleSymptom: (Symptom) -> Unit,
     onCreateAndAddSymptom: (String) -> Unit,
     onShowEducationalSheet: (String) -> Unit,
+    onDone: () -> Unit = {},
     symptomForContextMenu: Symptom? = null,
     symptomRenaming: Symptom? = null,
     symptomToDelete: Symptom? = null,
@@ -145,6 +148,13 @@ internal fun SymptomsPage(
                 onDeleteClicked = onDeleteClicked,
                 onEditDismissed = onEditDismissed,
             )
+        }
+
+        FilledTonalButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.daily_log_done_button))
         }
 
         Spacer(Modifier.height(dims.xl))

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPage.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.SelfImprovement
 import androidx.compose.material.icons.outlined.Star as StarOutlined
 import androidx.compose.material.icons.outlined.WaterDrop
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -60,6 +61,7 @@ import com.veleda.cyclewise.ui.theme.RhythmWiseColors
  * @param onLibidoChanged Callback when the user selects or deselects a libido score.
  * @param onWaterIncrement Callback when the user taps the water increment button.
  * @param onWaterDecrement Callback when the user taps the water decrement button.
+ * @param onDone Callback when the user taps the "Done" button to return to the Tracker.
  * @param onShowEducationalSheet Callback to display educational content for the given tag.
  * @param coachMarkState Optional coach-mark state for walkthrough integration.
  * @param activeHintKey The currently active walkthrough hint key, or `null` when no
@@ -77,6 +79,7 @@ internal fun WellnessPage(
     onLibidoChanged: (Int?) -> Unit,
     onWaterIncrement: () -> Unit,
     onWaterDecrement: () -> Unit,
+    onDone: () -> Unit = {},
     onShowEducationalSheet: (String) -> Unit,
     coachMarkState: CoachMarkState? = null,
     activeHintKey: HintKey? = null,
@@ -192,6 +195,13 @@ internal fun WellnessPage(
                 modifier = Modifier.fillMaxWidth(),
                 enabled = waterEnabled,
             )
+        }
+
+        FilledTonalButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.daily_log_done_button))
         }
 
         // Bottom spacer for comfortable scrolling past bottom nav

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="daily_log_create_symptom">Create and Add Symptom</string>
     <string name="daily_log_symptom_save_error">Failed to save symptom. Please try again.</string>
     <string name="daily_log_medication_save_error">Failed to save medication. Please try again.</string>
+    <string name="daily_log_done_button">Done</string>
 
     <!-- Library Edit/Delete -->
     <string name="library_rename">Rename</string>

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/MedicationsPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/MedicationsPageTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import com.veleda.cyclewise.RobolectricTestApp
@@ -47,6 +48,7 @@ class MedicationsPageTest {
         onToggleMedication: (Medication) -> Unit = {},
         onCreateAndAddMedication: (String) -> Unit = {},
         onShowEducationalSheet: (String) -> Unit = {},
+        onDone: () -> Unit = {},
         medicationForContextMenu: Medication? = null,
         medicationRenaming: Medication? = null,
         medicationToDelete: Medication? = null,
@@ -68,6 +70,7 @@ class MedicationsPageTest {
                         onToggleMedication = onToggleMedication,
                         onCreateAndAddMedication = onCreateAndAddMedication,
                         onShowEducationalSheet = onShowEducationalSheet,
+                        onDone = onDone,
                         medicationForContextMenu = medicationForContextMenu,
                         medicationRenaming = medicationRenaming,
                         medicationToDelete = medicationToDelete,
@@ -296,6 +299,25 @@ class MedicationsPageTest {
         composeTestRule.onNodeWithText("Delete Medication").assertIsDisplayed()
         composeTestRule.onNodeWithText("no logged entries", substring = true, ignoreCase = true)
             .assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region Done button
+
+    @Test
+    fun doneButton_WHEN_tapped_THEN_invokesCallback() {
+        // Given
+        var invoked = false
+        setContent(onDone = { invoked = true })
+
+        // When
+        composeTestRule.onNodeWithText("Done")
+            .performScrollTo()
+            .performClick()
+
+        // Then
+        assert(invoked) { "onDone was not invoked" }
     }
 
     // endregion

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/NotesTagsPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/NotesTagsPageTest.kt
@@ -34,6 +34,7 @@ class NotesTagsPageTest {
         onAddTag: (String) -> Unit = {},
         onRemoveTag: (String) -> Unit = {},
         onNoteChanged: (String) -> Unit = {},
+        onDone: () -> Unit = {},
     ) {
         composeTestRule.setContent {
             CompositionLocalProvider(LocalDimensions provides Dimensions()) {
@@ -44,6 +45,7 @@ class NotesTagsPageTest {
                         onAddTag = onAddTag,
                         onRemoveTag = onRemoveTag,
                         onNoteChanged = onNoteChanged,
+                        onDone = onDone,
                     )
                 }
             }
@@ -197,6 +199,25 @@ class NotesTagsPageTest {
         composeTestRule.onNodeWithText("Add any notes", substring = true)
             .performScrollTo()
             .assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region Done button
+
+    @Test
+    fun doneButton_WHEN_tapped_THEN_invokesCallback() {
+        // Given
+        var invoked = false
+        setContent(onDone = { invoked = true })
+
+        // When
+        composeTestRule.onNodeWithText("Done")
+            .performScrollTo()
+            .performClick()
+
+        // Then
+        assert(invoked) { "onDone was not invoked" }
     }
 
     // endregion

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/PeriodPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/PeriodPageTest.kt
@@ -44,6 +44,7 @@ class PeriodPageTest {
         onFlowChanged: (FlowIntensity?) -> Unit = {},
         onColorChanged: (PeriodColor?) -> Unit = {},
         onConsistencyChanged: (PeriodConsistency?) -> Unit = {},
+        onDone: () -> Unit = {},
         onShowEducationalSheet: (String) -> Unit = {},
         activeHintKey: HintKey? = null,
     ) {
@@ -59,6 +60,7 @@ class PeriodPageTest {
                         onFlowChanged = onFlowChanged,
                         onColorChanged = onColorChanged,
                         onConsistencyChanged = onConsistencyChanged,
+                        onDone = onDone,
                         onShowEducationalSheet = onShowEducationalSheet,
                         activeHintKey = activeHintKey,
                     )
@@ -249,6 +251,25 @@ class PeriodPageTest {
 
         // Then
         assert(captured == true) { "Expected onPeriodToggled(true), got $captured" }
+    }
+
+    // endregion
+
+    // region Done button
+
+    @Test
+    fun doneButton_WHEN_tapped_THEN_invokesCallback() {
+        // Given
+        var invoked = false
+        setContent(onDone = { invoked = true })
+
+        // When
+        composeTestRule.onNodeWithText("Done")
+            .performScrollTo()
+            .performClick()
+
+        // Then
+        assert(invoked) { "onDone was not invoked" }
     }
 
     // endregion

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/SymptomsPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/SymptomsPageTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTouchInput
 import com.veleda.cyclewise.RobolectricTestApp
@@ -53,6 +54,7 @@ class SymptomsPageTest {
         onToggleSymptom: (Symptom) -> Unit = {},
         onCreateAndAddSymptom: (String) -> Unit = {},
         onShowEducationalSheet: (String) -> Unit = {},
+        onDone: () -> Unit = {},
         symptomForContextMenu: Symptom? = null,
         symptomRenaming: Symptom? = null,
         symptomToDelete: Symptom? = null,
@@ -74,6 +76,7 @@ class SymptomsPageTest {
                         onToggleSymptom = onToggleSymptom,
                         onCreateAndAddSymptom = onCreateAndAddSymptom,
                         onShowEducationalSheet = onShowEducationalSheet,
+                        onDone = onDone,
                         symptomForContextMenu = symptomForContextMenu,
                         symptomRenaming = symptomRenaming,
                         symptomToDelete = symptomToDelete,
@@ -312,6 +315,25 @@ class SymptomsPageTest {
         composeTestRule.onNodeWithText("Delete Symptom").assertIsDisplayed()
         composeTestRule.onNodeWithText("no logged entries", substring = true, ignoreCase = true)
             .assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region Done button
+
+    @Test
+    fun doneButton_WHEN_tapped_THEN_invokesCallback() {
+        // Given
+        var invoked = false
+        setContent(onDone = { invoked = true })
+
+        // When
+        composeTestRule.onNodeWithText("Done")
+            .performScrollTo()
+            .performClick()
+
+        // Then
+        assert(invoked) { "onDone was not invoked" }
     }
 
     // endregion

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/log/pages/WellnessPageTest.kt
@@ -44,6 +44,7 @@ class WellnessPageTest {
         onLibidoChanged: (Int?) -> Unit = {},
         onWaterIncrement: () -> Unit = {},
         onWaterDecrement: () -> Unit = {},
+        onDone: () -> Unit = {},
         onShowEducationalSheet: (String) -> Unit = {},
         activeHintKey: HintKey? = null,
     ) {
@@ -61,6 +62,7 @@ class WellnessPageTest {
                         onLibidoChanged = onLibidoChanged,
                         onWaterIncrement = onWaterIncrement,
                         onWaterDecrement = onWaterDecrement,
+                        onDone = onDone,
                         onShowEducationalSheet = onShowEducationalSheet,
                         activeHintKey = activeHintKey,
                     )
@@ -287,6 +289,25 @@ class WellnessPageTest {
 
         // Then — callback fires (star is enabled)
         assert(captured == 3) { "Expected mood score 3, got $captured" }
+    }
+
+    // endregion
+
+    // region Done button
+
+    @Test
+    fun doneButton_WHEN_tapped_THEN_invokesCallback() {
+        // Given
+        var invoked = false
+        setContent(onDone = { invoked = true })
+
+        // When
+        composeTestRule.onNodeWithText("Done")
+            .performScrollTo()
+            .performClick()
+
+        // Then
+        assert(invoked) { "onDone was not invoked" }
     }
 
     // endregion


### PR DESCRIPTION
…to daily log

---
name: 🚀 Pull Request
about: Propose changes to the RhythmWise codebase

---

### Description

Add a FilledTonalButton at the bottom of every daily log tab page that
navigates back to the Tracker screen. From the DailyLogHome route it
switches to the Tracker tab; from the DailyLog detail route it pops the
back stack.

Add per-tab background tinting to the ScrollableTabRow: tabs with logged
data show an animated primaryContainer tint (0.4 alpha), providing
at-a-glance feedback on which tabs have been completed. Tint logic is
computed reactively from the existing UI state with no new ViewModel
changes needed.

### Related Issue

 Closes #112 

### Checklist

<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->