### PR TITLE
feat(backup): add database export and import for device migration (#115)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/PeriodDatabase.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/androidData/local/database/PeriodDatabase.kt
@@ -180,6 +180,14 @@ abstract class PeriodDatabase : RoomDatabase() {
 
     companion object {
         /**
+         * Current Room schema version — must stay in sync with [Database.version] above.
+         *
+         * Exposed as a constant so that [BackupManager] can embed it in the backup
+         * metadata and check imported backups without reflection.
+         */
+        const val SCHEMA_VERSION = 13
+
+        /**
          * Creates (or opens) the encrypted database backed by SQLCipher.
          *
          * ## Security: SupportFactory reference semantics

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/di/AppModule.kt
@@ -11,6 +11,7 @@ import org.koin.core.module.dsl.*
 import org.koin.dsl.module
 import org.koin.android.ext.koin.androidContext
 import com.veleda.cyclewise.domain.services.PassphraseService
+import com.veleda.cyclewise.services.BackupManager
 import com.veleda.cyclewise.services.PassphraseServiceAndroid
 import com.veleda.cyclewise.androidData.local.database.PeriodDatabase
 import com.veleda.cyclewise.androidData.local.database.rekeyRaw
@@ -244,9 +245,17 @@ val appModule = module {
 
     single { SessionManager(appSettings = get(), lockedWaterDraft = get()) }
 
+    single { BackupManager(context = androidContext(), saltStorage = get()) }
+
     viewModel { WaterTrackerViewModel(lockedWaterDraft = get()) }
 
-    viewModel { PassphraseViewModel(appSettings = get(), sessionManager = get()) }
+    viewModel {
+        PassphraseViewModel(
+            appSettings = get(),
+            sessionManager = get(),
+            backupManager = get(),
+        )
+    }
 
     viewModel {
         SettingsViewModel(
@@ -256,6 +265,7 @@ val appModule = module {
             hintPreferences = get(),
             deleteAllDataUseCase = get(),
             sessionManager = get(),
+            backupManager = get(),
         )
     }
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/BackupManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/BackupManager.kt
@@ -1,0 +1,421 @@
+package com.veleda.cyclewise.services
+
+import android.content.Context
+import android.net.Uri
+import android.util.Base64
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.veleda.cyclewise.BuildConfig
+import com.veleda.cyclewise.androidData.local.database.PeriodDatabase
+import com.veleda.cyclewise.domain.models.BackupMetadata
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator
+import org.bouncycastle.crypto.params.Argon2Parameters
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+/**
+ * Manages export and import of `.rwbackup` archives for device migration.
+ *
+ * A `.rwbackup` file is a standard ZIP archive containing:
+ * - `cyclewise.db` — the SQLCipher-encrypted Room database file.
+ * - `salt.txt` — the Base64-encoded Argon2id salt that was used to derive the encryption key.
+ * - `metadata.json` — a [BackupMetadata] JSON object with app version, schema version,
+ *   and export timestamp.
+ *
+ * **Singleton-scoped** because import must work before a session is unlocked (from the
+ * unlock screen or first-time setup screen). Export requires an active session; the caller
+ * passes the open [SupportSQLiteDatabase] for WAL checkpoint.
+ *
+ * @param context           Application context for resolving file paths and content URIs.
+ * @param saltStorage       Provides the current salt for export, and receives the imported
+ *                          salt during import via [SaltStorage.setSalt].
+ */
+class BackupManager(
+    private val context: Context,
+    private val saltStorage: SaltStorage,
+) {
+
+    private val json = Json { prettyPrint = true }
+
+    /**
+     * Exports the encrypted database, salt, and metadata to a `.rwbackup` ZIP archive
+     * at the user-selected [outputUri].
+     *
+     * **Requires an active session.** The caller must pass the open [writableDb] so that
+     * the WAL can be checkpointed before copying the database file.
+     *
+     * @param outputUri  SAF-provided URI for the output file.
+     * @param writableDb The open [SupportSQLiteDatabase] from the active session, used
+     *                   to execute `PRAGMA wal_checkpoint(TRUNCATE)` before export.
+     * @throws BackupException.IoError on any I/O failure.
+     */
+    suspend fun exportBackup(outputUri: Uri, writableDb: SupportSQLiteDatabase) {
+        withContext(Dispatchers.IO) {
+            // Flush WAL into main database file for a consistent snapshot
+            writableDb.query("PRAGMA wal_checkpoint(TRUNCATE)").use { it.moveToFirst() }
+
+            val dbFile = context.getDatabasePath(DB_NAME)
+            if (!dbFile.exists()) {
+                throw BackupException.IoError("Database file not found")
+            }
+
+            val saltBase64 = saltStorage.getSaltBase64()
+                ?: throw BackupException.IoError("No salt found — database has never been unlocked")
+
+            val metadata = BackupMetadata(
+                appVersionName = BuildConfig.VERSION_NAME,
+                appVersionCode = BuildConfig.VERSION_CODE,
+                schemaVersion = PeriodDatabase.SCHEMA_VERSION,
+                exportDateUtc = Instant.now().atOffset(ZoneOffset.UTC)
+                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+            )
+
+            val metadataJson = json.encodeToString(metadata)
+
+            context.contentResolver.openOutputStream(outputUri)?.use { outputStream ->
+                ZipOutputStream(outputStream).use { zip ->
+                    // metadata.json
+                    zip.putNextEntry(ZipEntry(ENTRY_METADATA))
+                    zip.write(metadataJson.toByteArray(Charsets.UTF_8))
+                    zip.closeEntry()
+
+                    // cyclewise.db
+                    zip.putNextEntry(ZipEntry(ENTRY_DATABASE))
+                    FileInputStream(dbFile).use { it.copyTo(zip) }
+                    zip.closeEntry()
+
+                    // salt.txt
+                    zip.putNextEntry(ZipEntry(ENTRY_SALT))
+                    zip.write(saltBase64.toByteArray(Charsets.UTF_8))
+                    zip.closeEntry()
+                }
+            } ?: throw BackupException.IoError("Could not open output stream for backup URI")
+        }
+    }
+
+    /**
+     * Validates a `.rwbackup` archive and returns its [BackupMetadata].
+     *
+     * Checks that the ZIP contains all three required entries (`metadata.json`,
+     * `cyclewise.db`, `salt.txt`), parses the metadata, and verifies the schema
+     * version is not newer than the current app.
+     *
+     * Does **not** require an active session.
+     *
+     * @param inputUri SAF-provided URI for the `.rwbackup` file.
+     * @return the parsed [BackupMetadata].
+     * @throws BackupException.InvalidArchive if the ZIP structure is invalid or entries are missing.
+     * @throws BackupException.SchemaVersionTooNew if the backup's schema version exceeds the app's.
+     */
+    suspend fun validateBackup(inputUri: Uri): BackupMetadata = withContext(Dispatchers.IO) {
+        val foundEntries = mutableSetOf<String>()
+        var metadataJsonString: String? = null
+
+        try {
+            context.contentResolver.openInputStream(inputUri)?.use { inputStream ->
+                ZipInputStream(inputStream).use { zip ->
+                    var entry = zip.nextEntry
+                    while (entry != null) {
+                        foundEntries.add(entry.name)
+                        if (entry.name == ENTRY_METADATA) {
+                            metadataJsonString = zip.readBytes().toString(Charsets.UTF_8)
+                        }
+                        zip.closeEntry()
+                        entry = zip.nextEntry
+                    }
+                }
+            } ?: throw BackupException.InvalidArchive()
+        } catch (e: BackupException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            throw BackupException.InvalidArchive()
+        }
+
+        val requiredEntries = setOf(ENTRY_METADATA, ENTRY_DATABASE, ENTRY_SALT)
+        val missing = requiredEntries - foundEntries
+        if (missing.isNotEmpty()) {
+            throw BackupException.InvalidArchive()
+        }
+
+        val metadata = try {
+            json.decodeFromString<BackupMetadata>(
+                metadataJsonString ?: throw BackupException.InvalidArchive(),
+            )
+        } catch (e: BackupException) {
+            throw e
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            throw BackupException.InvalidArchive()
+        }
+
+        if (metadata.schemaVersion > PeriodDatabase.SCHEMA_VERSION) {
+            throw BackupException.SchemaVersionTooNew(
+                backup = metadata.schemaVersion,
+                current = PeriodDatabase.SCHEMA_VERSION,
+            )
+        }
+
+        metadata
+    }
+
+    /**
+     * Verifies that [passphrase] can decrypt the database inside the backup archive.
+     *
+     * Extracts the salt and database to temporary files, derives a key using Argon2id
+     * with the **imported** salt (not the device's current salt), and attempts to open
+     * the database with raw SQLCipher. If the open succeeds, the passphrase is correct.
+     *
+     * Does **not** require an active session.
+     *
+     * @param inputUri   SAF-provided URI for the `.rwbackup` file.
+     * @param passphrase The passphrase to verify against the backup.
+     * @return `true` if the passphrase is correct.
+     * @throws BackupException.WrongPassphrase if the passphrase does not match.
+     * @throws BackupException.InvalidArchive if required entries are missing.
+     */
+    suspend fun verifyPassphrase(inputUri: Uri, passphrase: String): Boolean =
+        withContext(Dispatchers.IO) {
+            var tempDbFile: File? = null
+            var key: ByteArray? = null
+
+            try {
+                val (saltBytes, dbBytes) = extractSaltAndDb(inputUri)
+
+                // Derive key using the imported salt (not the device's current salt)
+                key = deriveKeyWithSalt(passphrase, saltBytes)
+
+                // Write DB to temp file for SQLCipher verification
+                tempDbFile = File(context.cacheDir, "verify_backup.db")
+                FileOutputStream(tempDbFile).use { it.write(dbBytes) }
+
+                // Attempt to open with raw SQLCipher
+                net.sqlcipher.database.SQLiteDatabase.loadLibs(context)
+                val rawDb = net.sqlcipher.database.SQLiteDatabase.openDatabase(
+                    tempDbFile.absolutePath,
+                    key.copyOf(),
+                    null,
+                    net.sqlcipher.database.SQLiteDatabase.OPEN_READONLY,
+                    null,
+                    null,
+                )
+                try {
+                    // Verify we can actually read data
+                    rawDb.rawQuery("SELECT count(*) FROM sqlite_master", null)
+                        .use { it.moveToFirst() }
+                } finally {
+                    rawDb.close()
+                }
+
+                true
+            } catch (e: BackupException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                throw BackupException.WrongPassphrase()
+            } finally {
+                key?.fill(0)
+                tempDbFile?.delete()
+                // Also clean up any -wal/-shm temp files SQLCipher may create
+                tempDbFile?.let {
+                    File(it.absolutePath + "-wal").delete()
+                    File(it.absolutePath + "-shm").delete()
+                }
+            }
+        }
+
+    /**
+     * Imports the database and salt from a `.rwbackup` archive, replacing the current data.
+     *
+     * Before replacing, creates rollback copies of the current database and salt. If any
+     * failure occurs after replacement begins, the rollback copies are restored.
+     *
+     * Does **not** require an active session — the caller must close any active session
+     * before calling this method.
+     *
+     * @param inputUri SAF-provided URI for the validated `.rwbackup` file.
+     * @throws BackupException.RollbackRestored if import fails but the previous data was
+     *         successfully restored from the rollback backup.
+     * @throws BackupException.IoError on unrecoverable I/O failure.
+     */
+    suspend fun importBackup(inputUri: Uri) {
+        withContext(Dispatchers.IO) {
+            val (saltBytes, dbBytes) = extractSaltAndDb(inputUri)
+
+            val dbFile = context.getDatabasePath(DB_NAME)
+            val walFile = File(dbFile.absolutePath + "-wal")
+            val shmFile = File(dbFile.absolutePath + "-shm")
+            val rollbackDbFile = File(dbFile.absolutePath + ".rollback")
+            val rollbackSaltBase64 = saltStorage.getSaltBase64()
+            var rollbackCreated = false
+
+            try {
+                // Create rollback backup if existing data is present
+                if (dbFile.exists()) {
+                    dbFile.copyTo(rollbackDbFile, overwrite = true)
+                    rollbackCreated = true
+                }
+
+                // Ensure parent directory exists
+                dbFile.parentFile?.mkdirs()
+
+                // Replace database file
+                FileOutputStream(dbFile).use { it.write(dbBytes) }
+
+                // Delete stale WAL and SHM files to prevent journal conflicts
+                walFile.delete()
+                shmFile.delete()
+
+                // Replace salt
+                saltStorage.setSalt(saltBytes)
+
+                // Success — clean up rollback files
+                rollbackDbFile.delete()
+            } catch (e: BackupException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                // Attempt to restore from rollback
+                if (rollbackCreated) {
+                    try {
+                        rollbackDbFile.copyTo(dbFile, overwrite = true)
+                        if (rollbackSaltBase64 != null) {
+                            val rollbackSalt = Base64.decode(rollbackSaltBase64, Base64.DEFAULT)
+                            saltStorage.setSalt(rollbackSalt)
+                        }
+                        rollbackDbFile.delete()
+                    } catch (@Suppress("TooGenericExceptionCaught") rollbackError: Exception) {
+                        throw BackupException.IoError(
+                            "Import failed and rollback also failed: ${rollbackError.message}",
+                        )
+                    }
+                    throw BackupException.RollbackRestored()
+                }
+                throw BackupException.IoError("Import failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Extracts the salt bytes and database bytes from a `.rwbackup` ZIP archive.
+     *
+     * @return A [Pair] of (saltBytes, dbBytes).
+     * @throws BackupException.InvalidArchive if required entries are missing.
+     */
+    private fun extractSaltAndDb(inputUri: Uri): Pair<ByteArray, ByteArray> {
+        var saltBase64String: String? = null
+        var dbBytes: ByteArray? = null
+
+        context.contentResolver.openInputStream(inputUri)?.use { inputStream ->
+            ZipInputStream(inputStream).use { zip ->
+                var entry = zip.nextEntry
+                while (entry != null) {
+                    when (entry.name) {
+                        ENTRY_SALT -> saltBase64String = zip.readBytes().toString(Charsets.UTF_8)
+                        ENTRY_DATABASE -> dbBytes = zip.readBytes()
+                    }
+                    zip.closeEntry()
+                    entry = zip.nextEntry
+                }
+            }
+        } ?: throw BackupException.InvalidArchive()
+
+        val saltBytes = Base64.decode(
+            saltBase64String ?: throw BackupException.InvalidArchive(),
+            Base64.DEFAULT,
+        )
+        return Pair(saltBytes, dbBytes ?: throw BackupException.InvalidArchive())
+    }
+
+    /**
+     * Derives a 32-byte AES key from [passphrase] using Argon2id with the provided [salt].
+     *
+     * Uses the same parameters as [PassphraseServiceAndroid] (parallelism=1, memory=64MB,
+     * iterations=3) but with an explicit salt rather than the device's stored salt. This
+     * allows passphrase verification against an imported backup without modifying the
+     * device's [SaltStorage].
+     *
+     * **Coupling note:** The Argon2 parameters here must stay in sync with
+     * [PassphraseServiceAndroid.deriveKey]. If those parameters change, update both.
+     *
+     * @param passphrase the raw user-entered secret.
+     * @param salt       the 16-byte salt extracted from the backup archive.
+     * @return a fresh 32-byte array containing the derived key. Caller must zeroize.
+     */
+    internal fun deriveKeyWithSalt(passphrase: String, salt: ByteArray): ByteArray {
+        val params = Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+            .withSalt(salt)
+            .withParallelism(1)
+            .withMemoryAsKB(ARGON2_MEMORY_KB)
+            .withIterations(ARGON2_ITERATIONS)
+            .build()
+
+        val generator = Argon2BytesGenerator().apply { init(params) }
+        val key = ByteArray(KEY_LENGTH)
+        generator.generateBytes(passphrase.toCharArray(), key, 0, KEY_LENGTH)
+        return key
+    }
+
+    companion object {
+        internal const val DB_NAME = "cyclewise.db"
+        internal const val ENTRY_METADATA = "metadata.json"
+        internal const val ENTRY_DATABASE = "cyclewise.db"
+        internal const val ENTRY_SALT = "salt.txt"
+        private const val KEY_LENGTH = 32
+        private const val ARGON2_MEMORY_KB = 64 * 1024
+        private const val ARGON2_ITERATIONS = 3
+
+        /**
+         * Generates the suggested filename for a backup export.
+         *
+         * Format: `RhythmWise_<yyyy-MM-dd>_<HHmmss>.rwbackup`
+         */
+        fun suggestedFilename(): String {
+            val now = Instant.now().atOffset(ZoneOffset.UTC)
+            val date = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+            val time = now.format(DateTimeFormatter.ofPattern("HHmmss"))
+            return "RhythmWise_${date}_$time.rwbackup"
+        }
+    }
+}
+
+/**
+ * Structured exception types for backup operations.
+ *
+ * Each subclass represents a distinct failure mode with a user-facing message.
+ * The sealed hierarchy ensures exhaustive handling via `when` expressions.
+ */
+sealed class BackupException(message: String) : Exception(message) {
+    /** The ZIP structure is invalid, missing required entries, or `metadata.json` is unparseable. */
+    class InvalidArchive : BackupException("Invalid or corrupted backup file")
+
+    /**
+     * The backup's schema version is greater than the current app's schema version.
+     *
+     * @property backup  the schema version in the backup archive.
+     * @property current the current app's schema version.
+     */
+    class SchemaVersionTooNew(
+        val backup: Int,
+        val current: Int,
+    ) : BackupException(
+        "Backup schema version ($backup) is newer than current ($current). Update the app.",
+    )
+
+    /** The passphrase does not match the encryption key used to create the backup. */
+    class WrongPassphrase : BackupException("Incorrect passphrase")
+
+    /** Import failed after replacement began, but previous data was restored from rollback. */
+    class RollbackRestored : BackupException(
+        "Import failed. Your previous data has been restored.",
+    )
+
+    /** Generic I/O failure during backup operations. */
+    class IoError(msg: String) : BackupException(msg)
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/SaltStorage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/services/SaltStorage.kt
@@ -39,6 +39,29 @@ class SaltStorage(context: Context) {
         return salt
     }
 
+    /**
+     * Replaces the persisted salt with [salt], which must be exactly [SALT_SIZE] bytes.
+     *
+     * Used during backup import to restore the salt that was active when the database
+     * was exported. After calling this, subsequent [getOrCreateSalt] calls will return
+     * the imported salt instead of generating a new one.
+     *
+     * @throws IllegalArgumentException if [salt] is not exactly [SALT_SIZE] bytes.
+     */
+    fun setSalt(salt: ByteArray) {
+        require(salt.size == SALT_SIZE) { "Salt must be $SALT_SIZE bytes, got ${salt.size}" }
+        val encoded = Base64.encodeToString(salt, Base64.NO_WRAP)
+        prefs.edit { putString(SALT_KEY, encoded) }
+    }
+
+    /**
+     * Returns the Base64-encoded salt string, or `null` if no salt has been persisted.
+     *
+     * Used by [BackupManager] to include the raw salt in backup archives without
+     * decoding and re-encoding.
+     */
+    fun getSaltBase64(): String? = prefs.getString(SALT_KEY, null)
+
     /** Removes the persisted salt, forcing a new one to be generated on the next unlock. */
     fun clear() {
         prefs.edit().clear().apply()

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/session/SessionManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/session/SessionManager.kt
@@ -1,6 +1,7 @@
 package com.veleda.cyclewise.session
 
 import android.util.Log
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.veleda.cyclewise.androidData.local.database.PeriodDatabase
 import com.veleda.cyclewise.androidData.local.database.RekeyVerificationFailedException
 import com.veleda.cyclewise.androidData.local.draft.LockedWaterDraft
@@ -113,6 +114,22 @@ class SessionManager(
      */
     val isSessionActive: Boolean
         get() = getKoin().getScopeOrNull("session") != null
+
+    /**
+     * Returns the open [SupportSQLiteDatabase] from the active session, or `null` if
+     * no session is active.
+     *
+     * Used by the backup export flow to checkpoint the WAL before copying the database
+     * file. Since only [SessionManager] is a [KoinComponent], this method provides a
+     * clean way for singleton-scoped ViewModels to access the session database without
+     * becoming Koin-aware themselves.
+     */
+    fun getOpenDatabase(): SupportSQLiteDatabase? {
+        return getKoin().getScopeOrNull("session")
+            ?.get<PeriodDatabase>()
+            ?.openHelper
+            ?.writableDatabase
+    }
 
     /**
      * Changes the database encryption passphrase.

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassPhraseScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassPhraseScreen.kt
@@ -1,5 +1,7 @@
 package com.veleda.cyclewise.ui.auth
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
@@ -46,6 +48,14 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import com.veleda.cyclewise.R
+import com.veleda.cyclewise.ui.backup.BackupErrorDialog
+import com.veleda.cyclewise.ui.backup.BackupMetadataPreviewDialog
+import com.veleda.cyclewise.ui.backup.BackupOverwriteConfirmDialog
+import com.veleda.cyclewise.ui.backup.BackupOverwriteWarningDialog
+import com.veleda.cyclewise.ui.backup.BackupPassphraseDialog
+import com.veleda.cyclewise.ui.backup.BackupProgressDialog
+import com.veleda.cyclewise.ui.backup.BackupSchemaErrorDialog
+import com.veleda.cyclewise.ui.backup.ImportStep
 import com.veleda.cyclewise.ui.components.ContentContainer
 import com.veleda.cyclewise.ui.components.SuccessAnimation
 import com.veleda.cyclewise.ui.theme.LocalDimensions
@@ -76,6 +86,13 @@ fun PassphraseScreen(
     val uiState by viewModel.uiState.collectAsState()
     var showSetupSuccess by remember { mutableStateOf(false) }
 
+    // SAF launcher for import (open an existing file)
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        uri?.let { viewModel.onEvent(PassphraseEvent.ImportFileSelected(it)) }
+    }
+
     // Collect one-time effects from the ViewModel (shared by both paths)
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
@@ -84,6 +101,9 @@ fun PassphraseScreen(
                 is PassphraseEffect.SetupComplete -> { showSetupSuccess = true }
                 is PassphraseEffect.ShowError -> {
                     // ShowError is handled within each sub-screen
+                }
+                is PassphraseEffect.LaunchImportPicker -> {
+                    importLauncher.launch(arrayOf("*/*"))
                 }
             }
         }
@@ -104,6 +124,9 @@ fun PassphraseScreen(
             effect = viewModel.effect,
         )
     }
+
+    // Import dialog flow (shared by both unlock and setup screens)
+    ImportDialogFlow(uiState = uiState, onEvent = viewModel::onEvent)
 
     // Success animation after first-time setup
     SuccessAnimation(
@@ -286,6 +309,20 @@ internal fun UnlockScreen(
                     yesterdayCupsForPrompt = waterState.yesterdayCupsForPrompt
                 )
             }
+
+            Spacer(Modifier.height(dims.md))
+
+            // Import backup button (subtle, de-emphasized)
+            TextButton(
+                onClick = { onEvent(PassphraseEvent.ImportBackupClicked) },
+                modifier = Modifier.testTag("import-backup-button")
+            ) {
+                Text(
+                    stringResource(R.string.passphrase_import_backup),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
         }
 
@@ -303,6 +340,87 @@ internal fun UnlockScreen(
                     contentDescription = stringResource(R.string.lottie_cd_loading),
                 )
             }
+        }
+    }
+}
+
+/**
+ * Import dialog flow shared between the unlock and setup screens.
+ *
+ * Displays the appropriate dialog based on [PassphraseUiState.importStep], reusing
+ * the dialog composables from [com.veleda.cyclewise.ui.backup.BackupDialogs].
+ */
+@Composable
+private fun ImportDialogFlow(
+    uiState: PassphraseUiState,
+    onEvent: (PassphraseEvent) -> Unit,
+) {
+    when (uiState.importStep) {
+        ImportStep.METADATA_PREVIEW -> {
+            uiState.importMetadata?.let { metadata ->
+                BackupMetadataPreviewDialog(
+                    metadata = metadata,
+                    onConfirm = { onEvent(PassphraseEvent.ImportMetadataConfirmed) },
+                    onDismiss = { onEvent(PassphraseEvent.ImportDismissed) },
+                )
+            }
+        }
+
+        ImportStep.PASSPHRASE_ENTRY -> {
+            BackupPassphraseDialog(
+                error = if (uiState.importPassphraseError == "wrong_passphrase") {
+                    stringResource(R.string.backup_passphrase_error_wrong)
+                } else {
+                    uiState.importPassphraseError
+                },
+                isVerifying = uiState.isVerifyingPassphrase,
+                onVerify = { onEvent(PassphraseEvent.ImportPassphraseEntered(it)) },
+                onDismiss = { onEvent(PassphraseEvent.ImportDismissed) },
+            )
+        }
+
+        ImportStep.FIRST_WARNING -> {
+            BackupOverwriteWarningDialog(
+                onConfirm = { onEvent(PassphraseEvent.ImportFirstWarningConfirmed) },
+                onDismiss = { onEvent(PassphraseEvent.ImportDismissed) },
+            )
+        }
+
+        ImportStep.SECOND_CONFIRM -> {
+            BackupOverwriteConfirmDialog(
+                confirmText = uiState.importConfirmText,
+                onTextChanged = { onEvent(PassphraseEvent.ImportConfirmTextChanged(it)) },
+                onConfirm = { onEvent(PassphraseEvent.ImportSecondConfirmed) },
+                onDismiss = { onEvent(PassphraseEvent.ImportDismissed) },
+            )
+        }
+
+        ImportStep.IMPORTING -> {
+            BackupProgressDialog(
+                title = stringResource(R.string.backup_progress_importing_title),
+                body = stringResource(R.string.backup_progress_importing_body),
+            )
+        }
+
+        ImportStep.IDLE -> { /* no dialog */ }
+    }
+
+    // Schema error or general error dialog
+    uiState.importError?.let { error ->
+        if (error.startsWith("schema_too_new:")) {
+            val parts = error.split(":")
+            val backupVersion = parts.getOrNull(1)?.toIntOrNull() ?: 0
+            val currentVersion = parts.getOrNull(2)?.toIntOrNull() ?: 0
+            BackupSchemaErrorDialog(
+                backupSchemaVersion = backupVersion,
+                currentSchemaVersion = currentVersion,
+                onDismiss = { onEvent(PassphraseEvent.ImportDismissed) },
+            )
+        } else {
+            BackupErrorDialog(
+                message = error,
+                onDismiss = { onEvent(PassphraseEvent.ImportDismissed) },
+            )
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseEvent.kt
@@ -1,5 +1,7 @@
 package com.veleda.cyclewise.ui.auth
 
+import android.net.Uri
+
 /**
  * Defines all user interactions that can occur on the Passphrase screen.
  */
@@ -22,6 +24,32 @@ sealed interface PassphraseEvent {
         val passphrase: String,
         val confirmation: String,
     ) : PassphraseEvent
+
+    // ── Backup Import ───────────────────────────────────────────────
+
+    /** User tapped "Import Backup" from the unlock or setup screen. */
+    data object ImportBackupClicked : PassphraseEvent
+
+    /** SAF returned the URI of the selected `.rwbackup` file. */
+    data class ImportFileSelected(val uri: Uri) : PassphraseEvent
+
+    /** User confirmed the metadata preview dialog. */
+    data object ImportMetadataConfirmed : PassphraseEvent
+
+    /** User submitted the passphrase for the backup. */
+    data class ImportPassphraseEntered(val passphrase: String) : PassphraseEvent
+
+    /** User confirmed the first overwrite warning dialog. */
+    data object ImportFirstWarningConfirmed : PassphraseEvent
+
+    /** User updated the text in the "type OVERWRITE" confirmation field. */
+    data class ImportConfirmTextChanged(val text: String) : PassphraseEvent
+
+    /** User typed "OVERWRITE" and confirmed — execute the import. */
+    data object ImportSecondConfirmed : PassphraseEvent
+
+    /** User cancelled the import at any step. */
+    data object ImportDismissed : PassphraseEvent
 }
 
 /**
@@ -57,4 +85,7 @@ sealed interface PassphraseEffect {
      *           toast or inline error on the passphrase screen.
      */
     data class ShowError(val message: String) : PassphraseEffect
+
+    /** Launch the SAF file picker for selecting a `.rwbackup` file to import. */
+    data object LaunchImportPicker : PassphraseEffect
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModel.kt
@@ -1,12 +1,19 @@
 package com.veleda.cyclewise.ui.auth
 
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.veleda.cyclewise.domain.models.BackupMetadata
+import com.veleda.cyclewise.services.BackupException
+import com.veleda.cyclewise.services.BackupManager
 import com.veleda.cyclewise.session.SessionManager
 import com.veleda.cyclewise.settings.AppSettings
+import com.veleda.cyclewise.ui.backup.ImportStep
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /** Minimum passphrase length enforced during first-time setup. */
 internal const val MIN_PASSPHRASE_LENGTH = 8
@@ -30,6 +37,14 @@ internal const val MAX_PASSPHRASE_LENGTH = 256
  *                              short). `null` means no error.
  * @property confirmationError  Inline error for the confirmation field during setup (e.g.
  *                              mismatch). `null` means no error.
+ * @property importStep             Current step in the backup import flow.
+ * @property importMetadata         Parsed metadata from the selected backup archive.
+ * @property importUri              SAF URI of the selected backup file.
+ * @property importPassphraseError  Inline error for the backup passphrase dialog.
+ * @property importConfirmText      Current text in the "type OVERWRITE" confirmation field.
+ * @property importError            Error message from the import flow, or `null`.
+ * @property isVerifyingPassphrase  Whether passphrase verification is in progress.
+ * @property importPassphrase       The verified passphrase for the import (stored transiently).
  */
 data class PassphraseUiState(
     val isUnlocking: Boolean = false,
@@ -37,6 +52,14 @@ data class PassphraseUiState(
     val isFirstTimeLoaded: Boolean = false,
     val passphraseError: String? = null,
     val confirmationError: String? = null,
+    val importStep: ImportStep = ImportStep.IDLE,
+    val importMetadata: BackupMetadata? = null,
+    val importUri: Uri? = null,
+    val importPassphraseError: String? = null,
+    val importConfirmText: String = "",
+    val importError: String? = null,
+    val isVerifyingPassphrase: Boolean = false,
+    val importPassphrase: String? = null,
 )
 
 /**
@@ -60,10 +83,13 @@ data class PassphraseUiState(
  *
  * @param appSettings    Used to determine first-time vs returning user.
  * @param sessionManager Centralizes all session scope lifecycle operations.
+ * @param backupManager  Handles `.rwbackup` archive validation, passphrase verification,
+ *                       and import for the backup import flow.
  */
 class PassphraseViewModel(
     private val appSettings: AppSettings,
     private val sessionManager: SessionManager,
+    private val backupManager: BackupManager,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PassphraseUiState())
@@ -107,8 +133,20 @@ class PassphraseViewModel(
             val passphrase = when (event) {
                 is PassphraseEvent.UnlockClicked -> event.passphrase
                 is PassphraseEvent.SetupClicked -> event.passphrase
+                else -> return
             }
             launchUnlock(passphrase)
+        }
+
+        // Import side effects
+        when (event) {
+            is PassphraseEvent.ImportBackupClicked -> {
+                viewModelScope.launch { _effect.emit(PassphraseEffect.LaunchImportPicker) }
+            }
+            is PassphraseEvent.ImportFileSelected -> launchValidateBackup(event.uri)
+            is PassphraseEvent.ImportPassphraseEntered -> launchVerifyImportPassphrase(event.passphrase)
+            is PassphraseEvent.ImportSecondConfirmed -> launchImportFromPassphraseScreen()
+            else -> { /* state-only or handled above */ }
         }
     }
 
@@ -124,6 +162,7 @@ class PassphraseViewModel(
      * - **SetupClicked**: validates passphrase length and confirmation match. Sets error
      *   fields on failure, or `isUnlocking = true` on success.
      */
+    @Suppress("CyclomaticComplexMethod")
     private fun reduce(state: PassphraseUiState, event: PassphraseEvent): PassphraseUiState {
         return when (event) {
             is PassphraseEvent.UnlockClicked -> {
@@ -141,6 +180,30 @@ class PassphraseViewModel(
                     else -> cleared.copy(isUnlocking = true)
                 }
             }
+
+            // ── Backup Import ───────────────────────────────────────
+            is PassphraseEvent.ImportBackupClicked -> state // effect-only
+            is PassphraseEvent.ImportFileSelected -> state // side effect validates
+            is PassphraseEvent.ImportMetadataConfirmed ->
+                state.copy(importStep = ImportStep.PASSPHRASE_ENTRY, importPassphraseError = null)
+            is PassphraseEvent.ImportPassphraseEntered ->
+                state.copy(isVerifyingPassphrase = true, importPassphraseError = null)
+            is PassphraseEvent.ImportFirstWarningConfirmed ->
+                state.copy(importStep = ImportStep.SECOND_CONFIRM, importConfirmText = "")
+            is PassphraseEvent.ImportConfirmTextChanged ->
+                state.copy(importConfirmText = event.text)
+            is PassphraseEvent.ImportSecondConfirmed ->
+                state.copy(importStep = ImportStep.IMPORTING, importConfirmText = "")
+            is PassphraseEvent.ImportDismissed -> state.copy(
+                importStep = ImportStep.IDLE,
+                importMetadata = null,
+                importUri = null,
+                importPassphraseError = null,
+                importConfirmText = "",
+                importError = null,
+                isVerifyingPassphrase = false,
+                importPassphrase = null,
+            )
         }
     }
 
@@ -167,12 +230,143 @@ class PassphraseViewModel(
                 } else {
                     _effect.emit(PassphraseEffect.NavigateToTracker)
                 }
-            } catch (e: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
                 Log.e("PassphraseUnlock", "Unlock failed: ${e.message}")
                 sessionManager.closeSession()
                 _effect.emit(PassphraseEffect.ShowError("Failed to unlock. Wrong passphrase?"))
             } finally {
                 _uiState.update { it.copy(isUnlocking = false) }
+            }
+        }
+    }
+
+    // ── Backup Import side effects ──────────────────────────────────
+
+    /**
+     * Validates the selected backup file and shows the metadata preview dialog.
+     */
+    private fun launchValidateBackup(uri: Uri) {
+        viewModelScope.launch {
+            try {
+                val metadata = backupManager.validateBackup(uri)
+                _uiState.update {
+                    it.copy(
+                        importStep = ImportStep.METADATA_PREVIEW,
+                        importMetadata = metadata,
+                        importUri = uri,
+                        importError = null,
+                    )
+                }
+            } catch (e: BackupException.SchemaVersionTooNew) {
+                _uiState.update {
+                    it.copy(importError = "schema_too_new:${e.backup}:${e.current}")
+                }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e("PassphraseVM", "Backup validation failed", e)
+                _uiState.update { it.copy(importError = e.message) }
+            }
+        }
+    }
+
+    /**
+     * Verifies the passphrase against the imported backup's database.
+     *
+     * On success:
+     * - **First-time users (setup screen):** Skips double confirmation and immediately
+     *   imports, then opens a session with the verified passphrase.
+     * - **Returning users (unlock screen):** Advances to the first overwrite warning.
+     */
+    private fun launchVerifyImportPassphrase(passphrase: String) {
+        viewModelScope.launch {
+            val uri = _uiState.value.importUri ?: return@launch
+            try {
+                backupManager.verifyPassphrase(uri, passphrase)
+
+                if (_uiState.value.isFirstTime) {
+                    // Fresh install — no existing data, skip confirmation, import immediately
+                    _uiState.update {
+                        it.copy(
+                            importStep = ImportStep.IMPORTING,
+                            isVerifyingPassphrase = false,
+                            importPassphrase = passphrase,
+                        )
+                    }
+                    performImportAndOpenSession(uri, passphrase)
+                } else {
+                    // Returning user — show overwrite warning
+                    _uiState.update {
+                        it.copy(
+                            importStep = ImportStep.FIRST_WARNING,
+                            isVerifyingPassphrase = false,
+                            importPassphraseError = null,
+                            importPassphrase = passphrase,
+                        )
+                    }
+                }
+            } catch (e: BackupException.WrongPassphrase) {
+                _uiState.update {
+                    it.copy(
+                        isVerifyingPassphrase = false,
+                        importPassphraseError = "wrong_passphrase",
+                    )
+                }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e("PassphraseVM", "Passphrase verification failed", e)
+                _uiState.update {
+                    it.copy(
+                        isVerifyingPassphrase = false,
+                        importPassphraseError = e.message,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Executes import from the passphrase screen (unlock screen path after double confirm).
+     */
+    private fun launchImportFromPassphraseScreen() {
+        viewModelScope.launch {
+            val uri = _uiState.value.importUri ?: return@launch
+            val passphrase = _uiState.value.importPassphrase ?: return@launch
+            performImportAndOpenSession(uri, passphrase)
+        }
+    }
+
+    /**
+     * Replaces the database and salt, then opens a session with the verified passphrase.
+     *
+     * Used by both the setup screen (directly after passphrase verification) and the
+     * unlock screen (after double confirmation).
+     */
+    private suspend fun performImportAndOpenSession(uri: Uri, passphrase: String) {
+        try {
+            withContext(Dispatchers.IO) {
+                sessionManager.closeSession()
+                backupManager.importBackup(uri)
+            }
+            // Mark as prepopulated so the setup screen is skipped next time
+            appSettings.setPrepopulated(true)
+            // Open session with the imported backup's passphrase
+            sessionManager.openSession(passphrase)
+            _uiState.update {
+                it.copy(
+                    importStep = ImportStep.IDLE,
+                    importMetadata = null,
+                    importUri = null,
+                    importPassphrase = null,
+                )
+            }
+            _effect.emit(PassphraseEffect.NavigateToTracker)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            Log.e("PassphraseVM", "Import failed", e)
+            sessionManager.closeSession()
+            _uiState.update {
+                it.copy(
+                    importStep = ImportStep.IDLE,
+                    importError = e.message,
+                    importPassphrase = null,
+                )
             }
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/SetupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/SetupScreen.kt
@@ -456,5 +456,19 @@ private fun CreatePassphrasePage(
         ) {
             Text(stringResource(R.string.setup_create_button))
         }
+
+        Spacer(Modifier.height(dims.md))
+
+        // Import backup link
+        TextButton(
+            onClick = { onEvent(PassphraseEvent.ImportBackupClicked) },
+            modifier = Modifier.testTag("setup-import-button"),
+        ) {
+            Text(
+                stringResource(R.string.setup_import_instead),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/backup/BackupDialogs.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/backup/BackupDialogs.kt
@@ -1,0 +1,354 @@
+package com.veleda.cyclewise.ui.backup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.veleda.cyclewise.R
+import com.veleda.cyclewise.domain.models.BackupMetadata
+import com.veleda.cyclewise.ui.theme.LocalDimensions
+
+/**
+ * Shows backup metadata (app version, schema version, export date) with
+ * Confirm/Cancel actions. Displayed after a `.rwbackup` file is selected
+ * and successfully validated.
+ *
+ * @param metadata    The parsed [BackupMetadata] from the backup archive.
+ * @param onConfirm   Called when the user taps "Continue" to proceed with import.
+ * @param onDismiss   Called when the user cancels the import.
+ */
+@Composable
+fun BackupMetadataPreviewDialog(
+    metadata: BackupMetadata,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val dims = LocalDimensions.current
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.backup_metadata_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(dims.sm)) {
+                Text(
+                    stringResource(R.string.backup_metadata_app_version, metadata.appVersionName),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    stringResource(R.string.backup_metadata_schema_version, metadata.schemaVersion),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    stringResource(R.string.backup_metadata_export_date, metadata.exportDateUtc),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        },
+        confirmButton = {
+            Button(onClick = onConfirm) {
+                Text(stringResource(R.string.backup_metadata_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_delete_first_cancel))
+            }
+        },
+    )
+}
+
+/**
+ * Passphrase entry dialog for verifying the backup's encryption passphrase.
+ *
+ * The passphrase text is stored in local [remember] state — never persisted
+ * to the ViewModel or disk.
+ *
+ * @param error        Inline error message (e.g. "Incorrect passphrase"), or `null` for no error.
+ * @param isVerifying  Whether passphrase verification is in progress (shows progress indicator).
+ * @param onVerify     Called with the entered passphrase when the user taps "Verify".
+ * @param onDismiss    Called when the user cancels.
+ */
+@Composable
+fun BackupPassphraseDialog(
+    error: String?,
+    isVerifying: Boolean,
+    onVerify: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val dims = LocalDimensions.current
+    var passphrase by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = { if (!isVerifying) onDismiss() },
+        title = { Text(stringResource(R.string.backup_passphrase_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(dims.sm)) {
+                Text(
+                    stringResource(R.string.backup_passphrase_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                OutlinedTextField(
+                    value = passphrase,
+                    onValueChange = { passphrase = it },
+                    label = { Text(stringResource(R.string.backup_passphrase_label)) },
+                    visualTransformation = if (passwordVisible) VisualTransformation.None
+                    else PasswordVisualTransformation(),
+                    trailingIcon = {
+                        TextButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Text(
+                                stringResource(
+                                    if (passwordVisible) R.string.passphrase_hide
+                                    else R.string.passphrase_show,
+                                ),
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                        }
+                    },
+                    isError = error != null,
+                    supportingText = if (error != null) {
+                        { Text(error, color = MaterialTheme.colorScheme.error) }
+                    } else {
+                        null
+                    },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("backup-passphrase-input"),
+                )
+
+                if (isVerifying) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(dims.md),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        Text(stringResource(R.string.backup_passphrase_verifying))
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onVerify(passphrase) },
+                enabled = passphrase.isNotBlank() && !isVerifying,
+            ) {
+                Text(stringResource(R.string.backup_passphrase_verify))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isVerifying,
+            ) {
+                Text(stringResource(R.string.settings_delete_first_cancel))
+            }
+        },
+    )
+}
+
+/**
+ * First overwrite warning dialog: "This will replace all existing data. This cannot be undone."
+ *
+ * @param onConfirm Called when the user taps "Replace Data" to proceed.
+ * @param onDismiss Called when the user cancels.
+ */
+@Composable
+fun BackupOverwriteWarningDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.backup_overwrite_first_title)) },
+        text = {
+            Text(stringResource(R.string.backup_overwrite_first_body))
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+            ) {
+                Text(stringResource(R.string.backup_overwrite_first_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_delete_first_cancel))
+            }
+        },
+    )
+}
+
+/**
+ * Second overwrite confirmation dialog requiring the user to type "OVERWRITE".
+ *
+ * Mirrors the existing "type DELETE" pattern from the data deletion flow in SecurityPage.
+ *
+ * @param confirmText The current text in the confirmation field.
+ * @param onTextChanged Called when the user types in the confirmation field.
+ * @param onConfirm    Called when the user taps "Confirm" (enabled only when text == "OVERWRITE").
+ * @param onDismiss    Called when the user cancels.
+ */
+@Composable
+fun BackupOverwriteConfirmDialog(
+    confirmText: String,
+    onTextChanged: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val dims = LocalDimensions.current
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.backup_overwrite_second_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(dims.md)) {
+                Text(stringResource(R.string.backup_overwrite_second_body))
+                OutlinedTextField(
+                    value = confirmText,
+                    onValueChange = onTextChanged,
+                    label = { Text(stringResource(R.string.backup_overwrite_field_label)) },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("backup-overwrite-input"),
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = confirmText == "OVERWRITE",
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+            ) {
+                Text(stringResource(R.string.backup_overwrite_first_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_delete_first_cancel))
+            }
+        },
+    )
+}
+
+/**
+ * Non-dismissable progress dialog shown during export or import operations.
+ *
+ * @param title The dialog title (e.g. "Exporting Backup" or "Importing Backup").
+ * @param body  The dialog body text (e.g. "Creating backup archive...").
+ */
+@Composable
+fun BackupProgressDialog(
+    title: String,
+    body: String,
+) {
+    val dims = LocalDimensions.current
+
+    AlertDialog(
+        onDismissRequest = { /* non-dismissable */ },
+        title = { Text(title) },
+        text = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(dims.md),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                Text(body)
+            }
+        },
+        confirmButton = { /* no buttons — non-dismissable */ },
+    )
+}
+
+/**
+ * Informational dialog shown when the backup's schema version exceeds the current app's.
+ *
+ * Tells the user to update the app before importing.
+ *
+ * @param backupSchemaVersion  The schema version from the backup archive.
+ * @param currentSchemaVersion The current app's schema version.
+ * @param onDismiss            Called when the user acknowledges.
+ */
+@Composable
+fun BackupSchemaErrorDialog(
+    backupSchemaVersion: Int,
+    currentSchemaVersion: Int,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.backup_schema_error_title)) },
+        text = {
+            Text(
+                stringResource(
+                    R.string.backup_schema_error_body,
+                    backupSchemaVersion,
+                    currentSchemaVersion,
+                ),
+            )
+        },
+        confirmButton = {
+            Button(onClick = onDismiss) {
+                Text(stringResource(R.string.about_close))
+            }
+        },
+    )
+}
+
+/**
+ * Generic error dialog for backup operations with a specific error message.
+ *
+ * @param message   The error message to display.
+ * @param onDismiss Called when the user acknowledges.
+ */
+@Composable
+fun BackupErrorDialog(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.backup_error_title)) },
+        text = { Text(message) },
+        confirmButton = {
+            Button(onClick = onDismiss) {
+                Text(stringResource(R.string.about_close))
+            }
+        },
+    )
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/backup/ImportStep.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/backup/ImportStep.kt
@@ -1,0 +1,30 @@
+package com.veleda.cyclewise.ui.backup
+
+/**
+ * Steps in the multi-dialog import flow, shared across Settings and Passphrase screens.
+ *
+ * The flow progresses linearly: [IDLE] → [METADATA_PREVIEW] → [PASSPHRASE_ENTRY] →
+ * (optionally [FIRST_WARNING] → [SECOND_CONFIRM]) → [IMPORTING].
+ *
+ * The double confirmation steps ([FIRST_WARNING] and [SECOND_CONFIRM]) are skipped
+ * on the first-time setup screen where no existing data is present.
+ */
+enum class ImportStep {
+    /** No import in progress. */
+    IDLE,
+
+    /** Showing the backup metadata preview dialog. */
+    METADATA_PREVIEW,
+
+    /** Prompting for the backup's encryption passphrase. */
+    PASSPHRASE_ENTRY,
+
+    /** First warning: "This will replace all existing data." */
+    FIRST_WARNING,
+
+    /** Second confirmation: user must type "OVERWRITE". */
+    SECOND_CONFIRM,
+
+    /** Import is actively running (non-dismissable progress dialog). */
+    IMPORTING,
+}

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsEvent.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsEvent.kt
@@ -1,5 +1,6 @@
 package com.veleda.cyclewise.ui.settings
 
+import android.net.Uri
 import com.veleda.cyclewise.ui.theme.ThemeMode
 
 /**
@@ -45,6 +46,38 @@ sealed interface SettingsEvent {
 
     /** User acknowledged the passphrase change success dialog and confirmed they saved the new passphrase. */
     data object ChangePassphraseSuccessAcknowledged : SettingsEvent
+
+    // ── Security (page 0) — Backup & Restore ────────────────────────
+
+    /** User tapped "Export Backup" to begin the export flow. */
+    data object ExportBackupClicked : SettingsEvent
+
+    /** SAF returned the URI for the export file. */
+    data class ExportToUri(val uri: Uri) : SettingsEvent
+
+    /** User tapped "Import Backup" to begin the import flow. */
+    data object ImportBackupClicked : SettingsEvent
+
+    /** SAF returned the URI of the selected `.rwbackup` file. */
+    data class ImportFileSelected(val uri: Uri) : SettingsEvent
+
+    /** User confirmed the metadata preview dialog to proceed with import. */
+    data object ImportMetadataConfirmed : SettingsEvent
+
+    /** User submitted the passphrase for the backup. */
+    data class ImportPassphraseEntered(val passphrase: String) : SettingsEvent
+
+    /** User confirmed the first overwrite warning dialog. */
+    data object ImportFirstWarningConfirmed : SettingsEvent
+
+    /** User updated the text in the "type OVERWRITE" confirmation field. */
+    data class ImportConfirmTextChanged(val text: String) : SettingsEvent
+
+    /** User typed "OVERWRITE" and tapped confirm — execute the import. */
+    data object ImportSecondConfirmed : SettingsEvent
+
+    /** User cancelled the import at any step. */
+    data object ImportDismissed : SettingsEvent
 
     // ── Appearance (page 1) — Insights ─────────────────────────────
 

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
@@ -2,6 +2,8 @@ package com.veleda.cyclewise.ui.settings
 
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -69,6 +71,22 @@ fun SettingsScreen(navController: NavController) {
     val aboutState by viewModel.aboutState.collectAsState()
     val context = LocalContext.current
     val passphraseChangedMessage = stringResource(R.string.settings_change_passphrase_success)
+    val exportSuccessMessage = stringResource(R.string.settings_export_success)
+    val importSuccessMessage = stringResource(R.string.backup_import_success)
+
+    // SAF launcher for export (create a new file)
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/zip"),
+    ) { uri ->
+        uri?.let { viewModel.onEvent(SettingsEvent.ExportToUri(it)) }
+    }
+
+    // SAF launcher for import (open an existing file)
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        uri?.let { viewModel.onEvent(SettingsEvent.ImportFileSelected(it)) }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
@@ -81,6 +99,25 @@ fun SettingsScreen(navController: NavController) {
 
                 is SettingsEffect.PassphraseChanged -> {
                     Toast.makeText(context, passphraseChangedMessage, Toast.LENGTH_SHORT).show()
+                    navController.navigate(NavRoute.Passphrase.route) {
+                        popUpTo(0) { inclusive = true }
+                    }
+                }
+
+                is SettingsEffect.LaunchExportPicker -> {
+                    exportLauncher.launch(effect.suggestedName)
+                }
+
+                is SettingsEffect.LaunchImportPicker -> {
+                    importLauncher.launch(arrayOf("*/*"))
+                }
+
+                is SettingsEffect.ExportSuccess -> {
+                    Toast.makeText(context, exportSuccessMessage, Toast.LENGTH_SHORT).show()
+                }
+
+                is SettingsEffect.BackupImported -> {
+                    Toast.makeText(context, importSuccessMessage, Toast.LENGTH_LONG).show()
                     navController.navigate(NavRoute.Passphrase.route) {
                         popUpTo(0) { inclusive = true }
                     }
@@ -146,6 +183,8 @@ internal fun SettingsContent(
     onEvent: (SettingsEvent) -> Unit,
     isSessionActive: Boolean,
     onLockNow: () -> Unit,
+    onExportClicked: () -> Unit = { onEvent(SettingsEvent.ExportBackupClicked) },
+    onImportClicked: () -> Unit = { onEvent(SettingsEvent.ImportBackupClicked) },
     onSeedDebugData: (() -> DebugSeederUseCase?)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -199,7 +238,14 @@ internal fun SettingsContent(
                 modifier = Modifier.fillMaxSize(),
             ) { page ->
                 when (page) {
-                    PAGE_SECURITY -> SecurityPage(securityState, onEvent, isSessionActive, onLockNow)
+                    PAGE_SECURITY -> SecurityPage(
+                        securityState,
+                        onEvent,
+                        isSessionActive,
+                        onLockNow,
+                        onExportClicked,
+                        onImportClicked,
+                    )
                     PAGE_APPEARANCE -> AppearancePage(appearanceState, onEvent)
                     PAGE_COLORS -> ColorsPage(colorsState, onEvent)
                     PAGE_NOTIFICATIONS -> NotificationsPage(notificationState, onEvent)

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModel.kt
@@ -1,15 +1,21 @@
 package com.veleda.cyclewise.ui.settings
 
+import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.veleda.cyclewise.domain.models.BackupMetadata
 import com.veleda.cyclewise.domain.models.EducationalArticle
 import com.veleda.cyclewise.domain.providers.EducationalContentProvider
 import com.veleda.cyclewise.domain.usecases.DeleteAllDataUseCase
 import com.veleda.cyclewise.reminders.ReminderScheduler
+import com.veleda.cyclewise.services.BackupException
+import com.veleda.cyclewise.services.BackupManager
 import com.veleda.cyclewise.session.ChangePassphraseResult
 import com.veleda.cyclewise.session.SessionManager
 import com.veleda.cyclewise.settings.AppSettings
 import com.veleda.cyclewise.ui.auth.MIN_PASSPHRASE_LENGTH
+import com.veleda.cyclewise.ui.backup.ImportStep
 import com.veleda.cyclewise.ui.coachmark.HintPreferences
 import com.veleda.cyclewise.ui.theme.ThemeMode
 import com.veleda.cyclewise.ui.tracker.CyclePhaseColors
@@ -39,6 +45,18 @@ sealed interface SettingsEffect {
 
     /** The passphrase was changed successfully; the UI should show a confirmation toast. */
     data object PassphraseChanged : SettingsEffect
+
+    /** Launch the SAF file picker for creating a backup file. */
+    data class LaunchExportPicker(val suggestedName: String) : SettingsEffect
+
+    /** Launch the SAF file picker for selecting a `.rwbackup` file to import. */
+    data object LaunchImportPicker : SettingsEffect
+
+    /** Backup was exported successfully; show a success message. */
+    data object ExportSuccess : SettingsEffect
+
+    /** Backup was imported successfully; navigate to passphrase screen for re-login. */
+    data object BackupImported : SettingsEffect
 }
 
 /**
@@ -57,6 +75,17 @@ sealed interface SettingsEffect {
  * @property showDeleteSecondConfirmation Whether the second "type DELETE" confirmation dialog is visible.
  * @property deleteConfirmText            Current text in the second dialog's confirmation field.
  * @property isDeletingData               Whether a data wipe is currently in progress.
+ * @property isExporting                  Whether a backup export is in progress.
+ * @property exportError                  Error message from the last export attempt, or `null`.
+ * @property importStep                   Current step in the multi-dialog import flow.
+ * @property importMetadata               Parsed metadata from the selected backup archive.
+ * @property importUri                    SAF URI of the selected backup file.
+ * @property importPassphraseError        Inline error for the backup passphrase dialog.
+ * @property importConfirmText            Current text in the "type OVERWRITE" confirmation field.
+ * @property importError                  Error message from the import flow, or `null`.
+ * @property isVerifyingPassphrase        Whether passphrase verification is in progress.
+ * @property importPassphrase             The verified passphrase for the import (stored transiently
+ *                                        during the confirmation flow, cleared after import).
  */
 data class SecuritySettingsState(
     val autolockMinutes: Int = 10,
@@ -68,6 +97,16 @@ data class SecuritySettingsState(
     val showDeleteSecondConfirmation: Boolean = false,
     val deleteConfirmText: String = "",
     val isDeletingData: Boolean = false,
+    val isExporting: Boolean = false,
+    val exportError: String? = null,
+    val importStep: ImportStep = ImportStep.IDLE,
+    val importMetadata: BackupMetadata? = null,
+    val importUri: Uri? = null,
+    val importPassphraseError: String? = null,
+    val importConfirmText: String = "",
+    val importError: String? = null,
+    val isVerifyingPassphrase: Boolean = false,
+    val importPassphrase: String? = null,
 )
 
 /**
@@ -211,6 +250,7 @@ class SettingsViewModel(
     private val hintPreferences: HintPreferences,
     private val deleteAllDataUseCase: DeleteAllDataUseCase,
     private val sessionManager: SessionManager,
+    private val backupManager: BackupManager,
 ) : ViewModel() {
 
     private val _securityState = MutableStateFlow(SecuritySettingsState())
@@ -395,7 +435,17 @@ class SettingsViewModel(
             is SettingsEvent.DeleteAllDataCancelled,
             is SettingsEvent.DeleteAllDataFirstConfirmed,
             is SettingsEvent.DeleteConfirmTextChanged,
-            is SettingsEvent.DeleteAllDataConfirmed ->
+            is SettingsEvent.DeleteAllDataConfirmed,
+            is SettingsEvent.ExportBackupClicked,
+            is SettingsEvent.ExportToUri,
+            is SettingsEvent.ImportBackupClicked,
+            is SettingsEvent.ImportFileSelected,
+            is SettingsEvent.ImportMetadataConfirmed,
+            is SettingsEvent.ImportPassphraseEntered,
+            is SettingsEvent.ImportFirstWarningConfirmed,
+            is SettingsEvent.ImportConfirmTextChanged,
+            is SettingsEvent.ImportSecondConfirmed,
+            is SettingsEvent.ImportDismissed ->
                 _securityState.update { reduceSecurity(it, event) }
 
             // ── Appearance state events ──────────────────────────────
@@ -627,6 +677,26 @@ class SettingsViewModel(
             is SettingsEvent.HydrationEndHourChanged ->
                 viewModelScope.launch { appSettings.setReminderHydrationEndHour(event.hour) }
 
+            is SettingsEvent.ExportBackupClicked -> {
+                viewModelScope.launch {
+                    _effect.emit(
+                        SettingsEffect.LaunchExportPicker(BackupManager.suggestedFilename()),
+                    )
+                }
+            }
+
+            is SettingsEvent.ExportToUri -> launchExport(event.uri)
+
+            is SettingsEvent.ImportBackupClicked -> {
+                viewModelScope.launch { _effect.emit(SettingsEffect.LaunchImportPicker) }
+            }
+
+            is SettingsEvent.ImportFileSelected -> launchValidateBackup(event.uri)
+
+            is SettingsEvent.ImportPassphraseEntered -> launchVerifyPassphrase(event.passphrase)
+
+            is SettingsEvent.ImportSecondConfirmed -> launchImport()
+
             // State-only events — no side effects needed.
             is SettingsEvent.ChangePassphraseRequested,
             is SettingsEvent.ChangePassphraseDismissed,
@@ -644,7 +714,11 @@ class SettingsViewModel(
             is SettingsEvent.ShowPermissionRationale,
             is SettingsEvent.DismissPermissionRationale,
             is SettingsEvent.ShowAboutDialog,
-            is SettingsEvent.DismissAboutDialog -> { /* state-only */ }
+            is SettingsEvent.DismissAboutDialog,
+            is SettingsEvent.ImportMetadataConfirmed,
+            is SettingsEvent.ImportFirstWarningConfirmed,
+            is SettingsEvent.ImportConfirmTextChanged,
+            is SettingsEvent.ImportDismissed -> { /* state-only */ }
         }
     }
 
@@ -713,6 +787,40 @@ class SettingsViewModel(
                     deleteConfirmText = "",
                     isDeletingData = true,
                 )
+
+            // ── Backup & Restore ────────────────────────────────────────
+
+            is SettingsEvent.ExportBackupClicked -> state // effect-only
+            is SettingsEvent.ExportToUri -> state.copy(isExporting = true, exportError = null)
+
+            is SettingsEvent.ImportBackupClicked -> state // effect-only
+            is SettingsEvent.ImportFileSelected -> state // side effect validates
+
+            is SettingsEvent.ImportMetadataConfirmed ->
+                state.copy(importStep = ImportStep.PASSPHRASE_ENTRY, importPassphraseError = null)
+
+            is SettingsEvent.ImportPassphraseEntered ->
+                state.copy(isVerifyingPassphrase = true, importPassphraseError = null)
+
+            is SettingsEvent.ImportFirstWarningConfirmed ->
+                state.copy(importStep = ImportStep.SECOND_CONFIRM, importConfirmText = "")
+
+            is SettingsEvent.ImportConfirmTextChanged ->
+                state.copy(importConfirmText = event.text)
+
+            is SettingsEvent.ImportSecondConfirmed ->
+                state.copy(importStep = ImportStep.IMPORTING, importConfirmText = "")
+
+            is SettingsEvent.ImportDismissed -> state.copy(
+                importStep = ImportStep.IDLE,
+                importMetadata = null,
+                importUri = null,
+                importPassphraseError = null,
+                importConfirmText = "",
+                importError = null,
+                isVerifyingPassphrase = false,
+                importPassphrase = null,
+            )
 
             else -> state
         }
@@ -938,6 +1046,130 @@ class SettingsViewModel(
                         isChangingPassphrase = false,
                         changePassphraseError = null,
                         showPassphraseSuccessDialog = true,
+                    )
+                }
+            }
+        }
+    }
+
+    // ── Backup & Restore side effects ───────────────────────────────
+
+    /**
+     * Exports the encrypted database to the SAF URI.
+     *
+     * Gets the open database from [SessionManager], runs WAL checkpoint and
+     * ZIP creation via [BackupManager], then emits [SettingsEffect.ExportSuccess]
+     * or updates state with the error.
+     */
+    private fun launchExport(uri: Uri) {
+        viewModelScope.launch {
+            try {
+                val db = sessionManager.getOpenDatabase()
+                    ?: throw BackupException.IoError("No active session")
+                backupManager.exportBackup(uri, db)
+                _securityState.update { it.copy(isExporting = false) }
+                _effect.emit(SettingsEffect.ExportSuccess)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e("SettingsVM", "Export failed", e)
+                _securityState.update {
+                    it.copy(isExporting = false, exportError = e.message)
+                }
+            }
+        }
+    }
+
+    /**
+     * Validates the selected backup file and shows the metadata preview dialog.
+     */
+    private fun launchValidateBackup(uri: Uri) {
+        viewModelScope.launch {
+            try {
+                val metadata = backupManager.validateBackup(uri)
+                _securityState.update {
+                    it.copy(
+                        importStep = ImportStep.METADATA_PREVIEW,
+                        importMetadata = metadata,
+                        importUri = uri,
+                        importError = null,
+                    )
+                }
+            } catch (e: BackupException.SchemaVersionTooNew) {
+                _securityState.update {
+                    it.copy(importError = "schema_too_new:${e.backup}:${e.current}")
+                }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e("SettingsVM", "Backup validation failed", e)
+                _securityState.update { it.copy(importError = e.message) }
+            }
+        }
+    }
+
+    /**
+     * Verifies the passphrase against the imported backup's database.
+     *
+     * On success, advances to the first overwrite warning step.
+     * On failure, shows an inline error on the passphrase dialog.
+     */
+    private fun launchVerifyPassphrase(passphrase: String) {
+        viewModelScope.launch {
+            val uri = _securityState.value.importUri ?: return@launch
+            try {
+                backupManager.verifyPassphrase(uri, passphrase)
+                _securityState.update {
+                    it.copy(
+                        importStep = ImportStep.FIRST_WARNING,
+                        isVerifyingPassphrase = false,
+                        importPassphraseError = null,
+                        importPassphrase = passphrase,
+                    )
+                }
+            } catch (e: BackupException.WrongPassphrase) {
+                _securityState.update {
+                    it.copy(
+                        isVerifyingPassphrase = false,
+                        importPassphraseError = "wrong_passphrase",
+                    )
+                }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e("SettingsVM", "Passphrase verification failed", e)
+                _securityState.update {
+                    it.copy(
+                        isVerifyingPassphrase = false,
+                        importPassphraseError = e.message,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Executes the import: closes the session, replaces the database and salt,
+     * and emits [SettingsEffect.BackupImported] to navigate to the passphrase screen.
+     */
+    private fun launchImport() {
+        viewModelScope.launch {
+            val uri = _securityState.value.importUri ?: return@launch
+            try {
+                withContext(Dispatchers.IO) {
+                    sessionManager.closeSession()
+                    backupManager.importBackup(uri)
+                }
+                _securityState.update {
+                    it.copy(
+                        importStep = ImportStep.IDLE,
+                        importMetadata = null,
+                        importUri = null,
+                        importPassphrase = null,
+                    )
+                }
+                _effect.emit(SettingsEffect.BackupImported)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                Log.e("SettingsVM", "Import failed", e)
+                _securityState.update {
+                    it.copy(
+                        importStep = ImportStep.IDLE,
+                        importError = e.message,
+                        importPassphrase = null,
                     )
                 }
             }

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/pages/SecurityPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/pages/SecurityPage.kt
@@ -40,6 +40,14 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.veleda.cyclewise.R
+import com.veleda.cyclewise.ui.backup.BackupErrorDialog
+import com.veleda.cyclewise.ui.backup.BackupMetadataPreviewDialog
+import com.veleda.cyclewise.ui.backup.BackupOverwriteConfirmDialog
+import com.veleda.cyclewise.ui.backup.BackupOverwriteWarningDialog
+import com.veleda.cyclewise.ui.backup.BackupPassphraseDialog
+import com.veleda.cyclewise.ui.backup.BackupProgressDialog
+import com.veleda.cyclewise.ui.backup.BackupSchemaErrorDialog
+import com.veleda.cyclewise.ui.backup.ImportStep
 import com.veleda.cyclewise.ui.settings.SecuritySettingsState
 import com.veleda.cyclewise.ui.settings.SettingsEvent
 import com.veleda.cyclewise.ui.settings.components.SettingsSectionCard
@@ -55,6 +63,8 @@ internal fun SecurityPage(
     onEvent: (SettingsEvent) -> Unit,
     isSessionActive: Boolean,
     onLockNow: () -> Unit,
+    onExportClicked: () -> Unit,
+    onImportClicked: () -> Unit,
 ) {
     val dims = LocalDimensions.current
 
@@ -134,6 +144,117 @@ internal fun SecurityPage(
         // Change Passphrase dialog
         if (state.showChangePassphraseDialog) {
             ChangePassphraseDialog(state = state, onEvent = onEvent)
+        }
+
+        // ── Backup & Restore Card ─────────────────────────────────────
+        SettingsSectionCard(title = stringResource(R.string.settings_section_backup)) {
+            Text(
+                stringResource(R.string.settings_backup_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = dims.md)
+            )
+            Spacer(Modifier.height(dims.sm))
+            FilledTonalButton(
+                enabled = isSessionActive && !state.isExporting,
+                onClick = onExportClicked,
+                modifier = Modifier.padding(horizontal = dims.md)
+            ) {
+                Text(stringResource(R.string.settings_export_backup))
+            }
+            Spacer(Modifier.height(dims.sm))
+            FilledTonalButton(
+                onClick = onImportClicked,
+                modifier = Modifier.padding(horizontal = dims.md)
+            ) {
+                Text(stringResource(R.string.settings_import_backup))
+            }
+        }
+
+        // Export progress dialog
+        if (state.isExporting) {
+            BackupProgressDialog(
+                title = stringResource(R.string.backup_progress_exporting_title),
+                body = stringResource(R.string.backup_progress_exporting_body),
+            )
+        }
+
+        // Export error dialog
+        state.exportError?.let { error ->
+            BackupErrorDialog(
+                message = stringResource(R.string.settings_export_error, error),
+                onDismiss = { onEvent(SettingsEvent.ImportDismissed) },
+            )
+        }
+
+        // Import dialog flow driven by importStep
+        when (state.importStep) {
+            ImportStep.METADATA_PREVIEW -> {
+                state.importMetadata?.let { metadata ->
+                    BackupMetadataPreviewDialog(
+                        metadata = metadata,
+                        onConfirm = { onEvent(SettingsEvent.ImportMetadataConfirmed) },
+                        onDismiss = { onEvent(SettingsEvent.ImportDismissed) },
+                    )
+                }
+            }
+
+            ImportStep.PASSPHRASE_ENTRY -> {
+                BackupPassphraseDialog(
+                    error = if (state.importPassphraseError == "wrong_passphrase") {
+                        stringResource(R.string.backup_passphrase_error_wrong)
+                    } else {
+                        state.importPassphraseError
+                    },
+                    isVerifying = state.isVerifyingPassphrase,
+                    onVerify = { onEvent(SettingsEvent.ImportPassphraseEntered(it)) },
+                    onDismiss = { onEvent(SettingsEvent.ImportDismissed) },
+                )
+            }
+
+            ImportStep.FIRST_WARNING -> {
+                BackupOverwriteWarningDialog(
+                    onConfirm = { onEvent(SettingsEvent.ImportFirstWarningConfirmed) },
+                    onDismiss = { onEvent(SettingsEvent.ImportDismissed) },
+                )
+            }
+
+            ImportStep.SECOND_CONFIRM -> {
+                BackupOverwriteConfirmDialog(
+                    confirmText = state.importConfirmText,
+                    onTextChanged = { onEvent(SettingsEvent.ImportConfirmTextChanged(it)) },
+                    onConfirm = { onEvent(SettingsEvent.ImportSecondConfirmed) },
+                    onDismiss = { onEvent(SettingsEvent.ImportDismissed) },
+                )
+            }
+
+            ImportStep.IMPORTING -> {
+                BackupProgressDialog(
+                    title = stringResource(R.string.backup_progress_importing_title),
+                    body = stringResource(R.string.backup_progress_importing_body),
+                )
+            }
+
+            ImportStep.IDLE -> { /* no dialog */ }
+        }
+
+        // Schema error dialog (shown when importError starts with "schema_too_new:")
+        state.importError?.let { error ->
+            if (error.startsWith("schema_too_new:")) {
+                val parts = error.split(":")
+                val backupVersion = parts.getOrNull(1)?.toIntOrNull() ?: 0
+                val currentVersion = parts.getOrNull(2)?.toIntOrNull() ?: 0
+                BackupSchemaErrorDialog(
+                    backupSchemaVersion = backupVersion,
+                    currentSchemaVersion = currentVersion,
+                    onDismiss = { onEvent(SettingsEvent.ImportDismissed) },
+                )
+            } else {
+                BackupErrorDialog(
+                    message = error,
+                    onDismiss = { onEvent(SettingsEvent.ImportDismissed) },
+                )
+            }
         }
 
         // ── Data Management Card ──────────────────────────────────────

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -427,6 +427,43 @@
     <string name="settings_change_passphrase_error_failed">Something went wrong. Your data is still protected by your current passphrase. Please try again.</string>
     <string name="settings_change_passphrase_error_verification_failed">The change could not be verified and was rolled back. Your current passphrase still works. Please try again.</string>
 
+    <!-- Backup & Restore -->
+    <string name="settings_section_backup">Backup &amp; Restore</string>
+    <string name="settings_backup_description">Export your encrypted database to transfer data between devices. The backup includes your database, encryption salt, and app metadata.</string>
+    <string name="settings_export_backup">Export Backup</string>
+    <string name="settings_import_backup">Import Backup</string>
+    <string name="settings_export_success">Backup exported successfully</string>
+    <string name="settings_export_error">Export failed: %s</string>
+    <string name="backup_metadata_title">Backup Details</string>
+    <string name="backup_metadata_app_version">App Version: %s</string>
+    <string name="backup_metadata_schema_version">Schema Version: %d</string>
+    <string name="backup_metadata_export_date">Export Date: %s</string>
+    <string name="backup_metadata_confirm">Continue</string>
+    <string name="backup_passphrase_title">Enter Backup Passphrase</string>
+    <string name="backup_passphrase_body">Enter the passphrase that was used when this backup was created.</string>
+    <string name="backup_passphrase_label">Backup passphrase</string>
+    <string name="backup_passphrase_verify">Verify</string>
+    <string name="backup_passphrase_error_wrong">Incorrect passphrase for this backup</string>
+    <string name="backup_passphrase_verifying">Verifying passphrase…</string>
+    <string name="backup_overwrite_first_title">Replace All Data?</string>
+    <string name="backup_overwrite_first_body">Importing this backup will permanently replace all existing data. This cannot be undone.\n\nYou will be logged out after import. You will need to log in with the passphrase from the imported backup.</string>
+    <string name="backup_overwrite_first_confirm">Replace Data</string>
+    <string name="backup_overwrite_second_title">Final Confirmation</string>
+    <string name="backup_overwrite_second_body">Type OVERWRITE below to confirm that you want to replace all existing data with the imported backup.</string>
+    <string name="backup_overwrite_field_label">Type OVERWRITE to confirm</string>
+    <string name="backup_progress_exporting_title">Exporting Backup</string>
+    <string name="backup_progress_exporting_body">Creating backup archive…</string>
+    <string name="backup_progress_importing_title">Importing Backup</string>
+    <string name="backup_progress_importing_body">Replacing database and restarting session…</string>
+    <string name="backup_schema_error_title">Incompatible Backup</string>
+    <string name="backup_schema_error_body">This backup was created with a newer version of RhythmWise (schema version %1$d). Your app supports schema version %2$d.\n\nPlease update the app before importing this backup.</string>
+    <string name="backup_error_title">Backup Error</string>
+    <string name="backup_error_invalid">Invalid or corrupted backup file. Please select a valid .rwbackup file.</string>
+    <string name="backup_error_rollback">Import failed. Your previous data has been restored.</string>
+    <string name="backup_import_success">Backup imported successfully. Please log in with the backup passphrase.</string>
+    <string name="passphrase_import_backup">Import Backup</string>
+    <string name="setup_import_instead">Have a backup? Import instead</string>
+
     <!-- Data Management -->
     <string name="settings_section_data_management">Data Management</string>
     <string name="settings_delete_all_data">Delete All Data</string>

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/services/BackupManagerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/services/BackupManagerTest.kt
@@ -1,0 +1,327 @@
+package com.veleda.cyclewise.services
+
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.veleda.cyclewise.RobolectricTestApp
+import com.veleda.cyclewise.androidData.local.database.PeriodDatabase
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricTestApp::class)
+class BackupManagerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var backupManager: BackupManager
+    private lateinit var mockSaltStorage: SaltStorage
+
+    private val validMetadataJson = """
+        {
+            "appVersionName": "1.0.0",
+            "appVersionCode": 2,
+            "schemaVersion": 13,
+            "exportDateUtc": "2026-03-19T14:30:22Z"
+        }
+    """.trimIndent()
+
+    @Before
+    fun setUp() {
+        mockSaltStorage = mockk<SaltStorage>()
+        val context = ApplicationProvider.getApplicationContext<RobolectricTestApp>()
+        backupManager = BackupManager(context, mockSaltStorage)
+    }
+
+    // --- validateBackup tests ---
+
+    @Test
+    fun validateBackup_WHEN_validZipWithAllEntries_THEN_returnsBackupMetadata() = runTest {
+        // ARRANGE
+        val zipFile = createZipFile(
+            BackupManager.ENTRY_METADATA to validMetadataJson.toByteArray(),
+            BackupManager.ENTRY_DATABASE to "fake-db-content".toByteArray(),
+            BackupManager.ENTRY_SALT to "c2FsdF9BXzE2X2J5dGVz".toByteArray(),
+        )
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        val metadata = backupManager.validateBackup(uri)
+
+        // ASSERT
+        assertEquals("1.0.0", metadata.appVersionName)
+        assertEquals(2, metadata.appVersionCode)
+        assertEquals(13, metadata.schemaVersion)
+        assertEquals("2026-03-19T14:30:22Z", metadata.exportDateUtc)
+    }
+
+    @Test(expected = BackupException.InvalidArchive::class)
+    fun validateBackup_WHEN_missingMetadataJson_THEN_throwsInvalidArchive() = runTest {
+        // ARRANGE — ZIP without metadata.json
+        val zipFile = createZipFile(
+            BackupManager.ENTRY_DATABASE to "fake-db-content".toByteArray(),
+            BackupManager.ENTRY_SALT to "c2FsdF9BXzE2X2J5dGVz".toByteArray(),
+        )
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        backupManager.validateBackup(uri)
+    }
+
+    @Test(expected = BackupException.InvalidArchive::class)
+    fun validateBackup_WHEN_missingDatabase_THEN_throwsInvalidArchive() = runTest {
+        // ARRANGE — ZIP without cyclewise.db
+        val zipFile = createZipFile(
+            BackupManager.ENTRY_METADATA to validMetadataJson.toByteArray(),
+            BackupManager.ENTRY_SALT to "c2FsdF9BXzE2X2J5dGVz".toByteArray(),
+        )
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        backupManager.validateBackup(uri)
+    }
+
+    @Test(expected = BackupException.InvalidArchive::class)
+    fun validateBackup_WHEN_missingSalt_THEN_throwsInvalidArchive() = runTest {
+        // ARRANGE — ZIP without salt.txt
+        val zipFile = createZipFile(
+            BackupManager.ENTRY_METADATA to validMetadataJson.toByteArray(),
+            BackupManager.ENTRY_DATABASE to "fake-db-content".toByteArray(),
+        )
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        backupManager.validateBackup(uri)
+    }
+
+    @Test(expected = BackupException.SchemaVersionTooNew::class)
+    fun validateBackup_WHEN_schemaVersionTooNew_THEN_throwsSchemaVersionTooNew() = runTest {
+        // ARRANGE — schema version higher than current
+        val futureSchemaVersion = PeriodDatabase.SCHEMA_VERSION + 1
+        val futureMetadataJson = """
+            {
+                "appVersionName": "2.0.0",
+                "appVersionCode": 10,
+                "schemaVersion": $futureSchemaVersion,
+                "exportDateUtc": "2026-03-19T14:30:22Z"
+            }
+        """.trimIndent()
+
+        val zipFile = createZipFile(
+            BackupManager.ENTRY_METADATA to futureMetadataJson.toByteArray(),
+            BackupManager.ENTRY_DATABASE to "fake-db-content".toByteArray(),
+            BackupManager.ENTRY_SALT to "c2FsdF9BXzE2X2J5dGVz".toByteArray(),
+        )
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        backupManager.validateBackup(uri)
+    }
+
+    @Test
+    fun validateBackup_WHEN_schemaVersionMatchesCurrent_THEN_succeeds() = runTest {
+        // ARRANGE — schema version exactly matches current
+        val metadataJson = """
+            {
+                "appVersionName": "1.0.0",
+                "appVersionCode": 2,
+                "schemaVersion": ${PeriodDatabase.SCHEMA_VERSION},
+                "exportDateUtc": "2026-03-19T14:30:22Z"
+            }
+        """.trimIndent()
+
+        val zipFile = createZipFile(
+            BackupManager.ENTRY_METADATA to metadataJson.toByteArray(),
+            BackupManager.ENTRY_DATABASE to "fake-db-content".toByteArray(),
+            BackupManager.ENTRY_SALT to "c2FsdF9BXzE2X2J5dGVz".toByteArray(),
+        )
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        val metadata = backupManager.validateBackup(uri)
+
+        // ASSERT
+        assertEquals(PeriodDatabase.SCHEMA_VERSION, metadata.schemaVersion)
+    }
+
+    @Test
+    fun validateBackup_WHEN_olderSchemaVersion_THEN_succeeds() = runTest {
+        // ARRANGE — schema version lower than current (forward-compatible)
+        val olderSchemaVersion = PeriodDatabase.SCHEMA_VERSION - 1
+        val metadataJson = """
+            {
+                "appVersionName": "0.9.0",
+                "appVersionCode": 1,
+                "schemaVersion": $olderSchemaVersion,
+                "exportDateUtc": "2026-03-19T14:30:22Z"
+            }
+        """.trimIndent()
+
+        val zipFile = createZipFile(
+            BackupManager.ENTRY_METADATA to metadataJson.toByteArray(),
+            BackupManager.ENTRY_DATABASE to "fake-db-content".toByteArray(),
+            BackupManager.ENTRY_SALT to "c2FsdF9BXzE2X2J5dGVz".toByteArray(),
+        )
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        val metadata = backupManager.validateBackup(uri)
+
+        // ASSERT
+        assertEquals(olderSchemaVersion, metadata.schemaVersion)
+    }
+
+    @Test(expected = BackupException.InvalidArchive::class)
+    fun validateBackup_WHEN_emptyZip_THEN_throwsInvalidArchive() = runTest {
+        // ARRANGE — ZIP with no entries at all
+        val zipFile = createZipFile()
+        val uri = Uri.fromFile(zipFile)
+
+        // ACT
+        backupManager.validateBackup(uri)
+    }
+
+    // --- suggestedFilename tests ---
+
+    @Test
+    fun suggestedFilename_THEN_matchesExpectedFormat() {
+        // ACT
+        val filename = BackupManager.suggestedFilename()
+
+        // ASSERT — format: RhythmWise_yyyy-MM-dd_HHmmss.rwbackup
+        assertTrue(
+            "Filename '$filename' should match RhythmWise_yyyy-MM-dd_HHmmss.rwbackup format",
+            filename.matches(Regex("""RhythmWise_\d{4}-\d{2}-\d{2}_\d{6}\.rwbackup""")),
+        )
+    }
+
+    @Test
+    fun suggestedFilename_THEN_startsWithRhythmWise() {
+        // ACT
+        val filename = BackupManager.suggestedFilename()
+
+        // ASSERT
+        assertTrue(
+            "Filename should start with 'RhythmWise_'",
+            filename.startsWith("RhythmWise_"),
+        )
+    }
+
+    @Test
+    fun suggestedFilename_THEN_endsWithRwbackupExtension() {
+        // ACT
+        val filename = BackupManager.suggestedFilename()
+
+        // ASSERT
+        assertTrue(
+            "Filename should end with '.rwbackup'",
+            filename.endsWith(".rwbackup"),
+        )
+    }
+
+    // --- deriveKeyWithSalt tests ---
+
+    @Test
+    fun deriveKeyWithSalt_THEN_returns32ByteKey() {
+        // ARRANGE
+        val passphrase = "test_passphrase"
+        val salt = "salt_A_16_bytes!".toByteArray() // 16 bytes
+
+        // ACT
+        val key = backupManager.deriveKeyWithSalt(passphrase, salt)
+
+        // ASSERT
+        assertEquals(
+            "Derived key should be exactly 32 bytes (256 bits)",
+            32,
+            key.size,
+        )
+    }
+
+    @Test
+    fun deriveKeyWithSalt_WHEN_sameInputs_THEN_producesSameKey() {
+        // ARRANGE
+        val passphrase = "deterministic_passphrase"
+        val salt = "salt_A_16_bytes!".toByteArray()
+
+        // ACT
+        val key1 = backupManager.deriveKeyWithSalt(passphrase, salt)
+        val key2 = backupManager.deriveKeyWithSalt(passphrase, salt)
+
+        // ASSERT
+        assertTrue(
+            "Same passphrase and salt should produce identical keys",
+            key1.contentEquals(key2),
+        )
+    }
+
+    @Test
+    fun deriveKeyWithSalt_WHEN_differentSalt_THEN_producesDifferentKey() {
+        // ARRANGE
+        val passphrase = "test_passphrase"
+        val saltA = "salt_A_16_bytes!".toByteArray()
+        val saltB = "salt_B_16_bytes!".toByteArray()
+
+        // ACT
+        val key1 = backupManager.deriveKeyWithSalt(passphrase, saltA)
+        val key2 = backupManager.deriveKeyWithSalt(passphrase, saltB)
+
+        // ASSERT
+        assertTrue(
+            "Different salts should produce different keys",
+            !key1.contentEquals(key2),
+        )
+    }
+
+    @Test
+    fun deriveKeyWithSalt_WHEN_differentPassphrase_THEN_producesDifferentKey() {
+        // ARRANGE
+        val salt = "salt_A_16_bytes!".toByteArray()
+
+        // ACT
+        val key1 = backupManager.deriveKeyWithSalt("passphrase_one", salt)
+        val key2 = backupManager.deriveKeyWithSalt("passphrase_two", salt)
+
+        // ASSERT
+        assertTrue(
+            "Different passphrases should produce different keys",
+            !key1.contentEquals(key2),
+        )
+    }
+
+    // --- Helpers ---
+
+    /**
+     * Creates a temporary ZIP file with the given entries.
+     *
+     * @param entries Pairs of (entry name, entry content bytes).
+     * @return A [File] pointing to the created ZIP in the [tempFolder].
+     */
+    private fun createZipFile(vararg entries: Pair<String, ByteArray>): File {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zip ->
+            for ((name, content) in entries) {
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(content)
+                zip.closeEntry()
+            }
+        }
+        val file = tempFolder.newFile("test_backup.rwbackup")
+        file.writeBytes(baos.toByteArray())
+        return file
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/services/SaltStorageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/services/SaltStorageTest.kt
@@ -1,0 +1,90 @@
+package com.veleda.cyclewise.services
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Unit tests for [SaltStorage], specifically the [SaltStorage.setSalt] method
+ * added for the backup import flow.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = com.veleda.cyclewise.RobolectricTestApp::class)
+class SaltStorageTest {
+
+    private lateinit var saltStorage: SaltStorage
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        saltStorage = SaltStorage(context)
+        saltStorage.clear()
+    }
+
+    @Test
+    fun `setSalt stores the salt and getOrCreateSalt returns it`() {
+        // Given a known salt value
+        val importedSalt = ByteArray(16) { it.toByte() }
+
+        // When we set it
+        saltStorage.setSalt(importedSalt)
+
+        // Then getOrCreateSalt returns the same bytes
+        val retrieved = saltStorage.getOrCreateSalt()
+        assertContentEquals(importedSalt, retrieved)
+    }
+
+    @Test
+    fun `setSalt overwrites a previously generated salt`() {
+        // Given an auto-generated salt exists
+        val originalSalt = saltStorage.getOrCreateSalt()
+
+        // When we overwrite it with an imported salt
+        val importedSalt = ByteArray(16) { (0xFF - it).toByte() }
+        saltStorage.setSalt(importedSalt)
+
+        // Then the retrieved salt is the imported one, not the original
+        val retrieved = saltStorage.getOrCreateSalt()
+        assertContentEquals(importedSalt, retrieved)
+    }
+
+    @Test
+    fun `setSalt rejects salt that is too short`() {
+        val tooShort = ByteArray(8)
+        assertFailsWith<IllegalArgumentException> {
+            saltStorage.setSalt(tooShort)
+        }
+    }
+
+    @Test
+    fun `setSalt rejects salt that is too long`() {
+        val tooLong = ByteArray(32)
+        assertFailsWith<IllegalArgumentException> {
+            saltStorage.setSalt(tooLong)
+        }
+    }
+
+    @Test
+    fun `getSaltBase64 returns null when no salt exists`() {
+        // Given a cleared storage
+        saltStorage.clear()
+
+        // Then getSaltBase64 returns null
+        kotlin.test.assertNull(saltStorage.getSaltBase64())
+    }
+
+    @Test
+    fun `getSaltBase64 returns non-null after salt is created`() {
+        // Given a salt has been generated
+        saltStorage.getOrCreateSalt()
+
+        // Then getSaltBase64 returns a non-null Base64 string
+        kotlin.test.assertNotNull(saltStorage.getSaltBase64())
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/auth/PassphraseViewModelTest.kt
@@ -1,8 +1,11 @@
 package com.veleda.cyclewise.ui.auth
 
+import app.cash.turbine.test
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import android.util.Log
+import com.veleda.cyclewise.services.BackupManager
 import com.veleda.cyclewise.session.SessionManager
+import com.veleda.cyclewise.ui.backup.ImportStep
 import com.veleda.cyclewise.settings.AppSettings
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -44,12 +47,14 @@ class PassphraseViewModelTest {
 
     private lateinit var mockAppSettings: AppSettings
     private lateinit var mockSessionManager: SessionManager
+    private lateinit var mockBackupManager: BackupManager
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         mockAppSettings = mockk(relaxed = true)
         mockSessionManager = mockk(relaxed = true)
+        mockBackupManager = mockk(relaxed = true)
 
         // Mock android.util.Log which throws RuntimeException("Stub!") in
         // plain JUnit tests. The unlock() catch block calls Log.e().
@@ -66,6 +71,7 @@ class PassphraseViewModelTest {
         return PassphraseViewModel(
             appSettings = mockAppSettings,
             sessionManager = mockSessionManager,
+            backupManager = mockBackupManager,
         )
     }
 
@@ -278,5 +284,46 @@ class PassphraseViewModelTest {
         assertNull(state.passphraseError)
         assertNull(state.confirmationError)
         coVerify(exactly = 1) { mockSessionManager.openSession("validpassphrase") }
+    }
+
+    // ── Backup Import ────────────────────────────────────────────────
+
+    @Test
+    fun `onEvent ImportBackupClicked THEN emitsLaunchImportPicker`() = runTest {
+        // GIVEN — returning user
+        every { mockAppSettings.isPrepopulated } returns flowOf(true)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — import backup clicked
+        viewModel.effect.test {
+            viewModel.onEvent(PassphraseEvent.ImportBackupClicked)
+            advanceUntilIdle()
+
+            // THEN — LaunchImportPicker effect is emitted
+            assertEquals(PassphraseEffect.LaunchImportPicker, awaitItem())
+        }
+    }
+
+    @Test
+    fun `onEvent ImportDismissed THEN resetsImportState`() = runTest {
+        // GIVEN — returning user
+        every { mockAppSettings.isPrepopulated } returns flowOf(true)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — import dismissed
+        viewModel.onEvent(PassphraseEvent.ImportDismissed)
+
+        // THEN — all import fields are reset to defaults
+        val state = viewModel.uiState.value
+        assertEquals(ImportStep.IDLE, state.importStep)
+        assertNull(state.importMetadata)
+        assertNull(state.importUri)
+        assertNull(state.importPassphraseError)
+        assertEquals("", state.importConfirmText)
+        assertNull(state.importError)
+        assertFalse(state.isVerifyingPassphrase)
+        assertNull(state.importPassphrase)
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/backup/BackupDialogsTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/backup/BackupDialogsTest.kt
@@ -1,0 +1,278 @@
+package com.veleda.cyclewise.ui.backup
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTextInput
+import com.veleda.cyclewise.RobolectricTestApp
+import com.veleda.cyclewise.domain.models.BackupMetadata
+import com.veleda.cyclewise.ui.theme.Dimensions
+import com.veleda.cyclewise.ui.theme.LocalDimensions
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric-based Compose UI tests for the backup dialog composables
+ * in [BackupDialogs].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricTestApp::class)
+class BackupDialogsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val testMetadata = BackupMetadata(
+        appVersionName = "1.0.0",
+        appVersionCode = 2,
+        schemaVersion = 13,
+        exportDateUtc = "2026-03-19T14:30:22Z",
+    )
+
+    // region MetadataPreviewDialog
+
+    @Test
+    fun metadataPreviewDialog_WHEN_rendered_THEN_displaysAllFields() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupMetadataPreviewDialog(
+                        metadata = testMetadata,
+                        onConfirm = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNodeWithText("Backup Details").assertIsDisplayed()
+        composeTestRule.onNodeWithText("App Version: 1.0.0", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Schema Version: 13", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Export Date: 2026-03-19T14:30:22Z", substring = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Continue").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cancel").assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region OverwriteConfirmDialog
+
+    @Test
+    fun overwriteConfirmDialog_WHEN_textEmpty_THEN_confirmDisabled() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupOverwriteConfirmDialog(
+                        confirmText = "",
+                        onTextChanged = {},
+                        onConfirm = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNode(
+            hasText("Replace Data", substring = true, ignoreCase = true).and(hasClickAction()),
+        ).assertIsNotEnabled()
+    }
+
+    @Test
+    fun overwriteConfirmDialog_WHEN_overwriteTyped_THEN_confirmEnabled() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupOverwriteConfirmDialog(
+                        confirmText = "OVERWRITE",
+                        onTextChanged = {},
+                        onConfirm = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNode(
+            hasText("Replace Data", substring = true, ignoreCase = true).and(hasClickAction()),
+        ).assertIsEnabled()
+    }
+
+    @Test
+    fun overwriteConfirmDialog_WHEN_partialText_THEN_confirmDisabled() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupOverwriteConfirmDialog(
+                        confirmText = "OVER",
+                        onTextChanged = {},
+                        onConfirm = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNode(
+            hasText("Replace Data", substring = true, ignoreCase = true).and(hasClickAction()),
+        ).assertIsNotEnabled()
+    }
+
+    // endregion
+
+    // region PassphraseDialog
+
+    @Test
+    fun passphraseDialog_WHEN_errorProvided_THEN_showsErrorText() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupPassphraseDialog(
+                        error = "Incorrect passphrase for this backup",
+                        isVerifying = false,
+                        onVerify = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNodeWithText("Enter Backup Passphrase").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Incorrect passphrase for this backup").assertIsDisplayed()
+    }
+
+    @Test
+    fun passphraseDialog_WHEN_noError_THEN_errorTextNotDisplayed() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupPassphraseDialog(
+                        error = null,
+                        isVerifying = false,
+                        onVerify = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNodeWithText("Enter Backup Passphrase").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Incorrect passphrase for this backup").assertDoesNotExist()
+    }
+
+    @Test
+    fun passphraseDialog_WHEN_isVerifying_THEN_verifyButtonDisabled() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupPassphraseDialog(
+                        error = null,
+                        isVerifying = true,
+                        onVerify = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNodeWithText("Verifying passphrase", substring = true).assertIsDisplayed()
+        composeTestRule.onNode(
+            hasText("Verify").and(hasClickAction()),
+        ).assertIsNotEnabled()
+    }
+
+    @Test
+    fun passphraseDialog_WHEN_passphraseEnteredAndNotVerifying_THEN_verifyButtonEnabled() {
+        // Given
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupPassphraseDialog(
+                        error = null,
+                        isVerifying = false,
+                        onVerify = {},
+                        onDismiss = {},
+                    )
+                }
+            }
+        }
+
+        // When
+        composeTestRule.onNodeWithTag("backup-passphrase-input").performTextInput("mypassphrase")
+
+        // Then
+        composeTestRule.onNode(
+            hasText("Verify").and(hasClickAction()),
+        ).assertIsEnabled()
+    }
+
+    // endregion
+
+    // region ProgressDialog
+
+    @Test
+    fun progressDialog_WHEN_rendered_THEN_showsTitleAndBody() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupProgressDialog(
+                        title = "Exporting Backup",
+                        body = "Creating backup archive...",
+                    )
+                }
+            }
+        }
+
+        // Then
+        composeTestRule.onNodeWithText("Exporting Backup").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Creating backup archive...").assertIsDisplayed()
+    }
+
+    @Test
+    fun progressDialog_WHEN_rendered_THEN_hasNoButtons() {
+        // Given / When
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalDimensions provides Dimensions()) {
+                MaterialTheme {
+                    BackupProgressDialog(
+                        title = "Importing Backup",
+                        body = "Restoring data...",
+                    )
+                }
+            }
+        }
+
+        // Then — no confirm or cancel buttons exist
+        composeTestRule.onNodeWithText("Importing Backup").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Cancel").assertDoesNotExist()
+        composeTestRule.onNodeWithText("OK").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Close").assertDoesNotExist()
+    }
+
+    // endregion
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModelTest.kt
@@ -7,6 +7,8 @@ import com.veleda.cyclewise.domain.models.EducationalArticle
 import com.veleda.cyclewise.domain.providers.EducationalContentProvider
 import com.veleda.cyclewise.domain.usecases.DeleteAllDataUseCase
 import com.veleda.cyclewise.reminders.ReminderScheduler
+import com.veleda.cyclewise.services.BackupManager
+import com.veleda.cyclewise.ui.backup.ImportStep
 import com.veleda.cyclewise.session.ChangePassphraseResult
 import com.veleda.cyclewise.session.SessionManager
 import com.veleda.cyclewise.settings.AppSettings
@@ -59,6 +61,7 @@ class SettingsViewModelTest {
     private lateinit var mockHintPreferences: HintPreferences
     private lateinit var mockDeleteAllDataUseCase: DeleteAllDataUseCase
     private lateinit var mockSessionManager: SessionManager
+    private lateinit var mockBackupManager: BackupManager
 
     @Before
     fun setUp() {
@@ -70,6 +73,7 @@ class SettingsViewModelTest {
         mockHintPreferences = mockk(relaxed = true)
         mockDeleteAllDataUseCase = mockk(relaxed = true)
         mockSessionManager = mockk(relaxed = true)
+        mockBackupManager = mockk(relaxed = true)
 
         // Configure all AppSettings flows to return defaults.
         every { mockAppSettings.themeMode } returns flowOf("system")
@@ -118,6 +122,7 @@ class SettingsViewModelTest {
             hintPreferences = mockHintPreferences,
             deleteAllDataUseCase = mockDeleteAllDataUseCase,
             sessionManager = mockSessionManager,
+            backupManager = mockBackupManager,
         )
     }
 
@@ -1161,5 +1166,100 @@ class SettingsViewModelTest {
 
         // THEN — reduce hides dialog
         assertFalse(viewModel.aboutState.value.showAboutDialog)
+    }
+
+    // ── Backup & Restore ────────────────────────────────────────────
+
+    @Test
+    fun `onEvent ExportBackupClicked THEN emitsLaunchExportPicker`() = runTest {
+        // GIVEN — ViewModel with defaults
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — export backup clicked
+        viewModel.effect.test {
+            viewModel.onEvent(SettingsEvent.ExportBackupClicked)
+            advanceUntilIdle()
+
+            // THEN — LaunchExportPicker effect is emitted
+            val effect = awaitItem()
+            assertTrue(effect is SettingsEffect.LaunchExportPicker)
+        }
+    }
+
+    @Test
+    fun `onEvent ImportBackupClicked THEN emitsLaunchImportPicker`() = runTest {
+        // GIVEN — ViewModel with defaults
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — import backup clicked
+        viewModel.effect.test {
+            viewModel.onEvent(SettingsEvent.ImportBackupClicked)
+            advanceUntilIdle()
+
+            // THEN — LaunchImportPicker effect is emitted
+            assertEquals(SettingsEffect.LaunchImportPicker, awaitItem())
+        }
+    }
+
+    @Test
+    fun `onEvent ImportDismissed THEN resetsImportState`() = runTest {
+        // GIVEN — ViewModel with defaults
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — import dismissed
+        viewModel.onEvent(SettingsEvent.ImportDismissed)
+
+        // THEN — all import fields are reset to defaults
+        val state = viewModel.securityState.value
+        assertEquals(ImportStep.IDLE, state.importStep)
+        assertNull(state.importMetadata)
+        assertNull(state.importUri)
+        assertNull(state.importPassphraseError)
+        assertEquals("", state.importConfirmText)
+        assertNull(state.importError)
+        assertFalse(state.isVerifyingPassphrase)
+        assertNull(state.importPassphrase)
+    }
+
+    @Test
+    fun `onEvent ImportMetadataConfirmed THEN advancesToPassphraseEntry`() = runTest {
+        // GIVEN — ViewModel with defaults
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — import metadata confirmed
+        viewModel.onEvent(SettingsEvent.ImportMetadataConfirmed)
+
+        // THEN — importStep advances to PASSPHRASE_ENTRY
+        assertEquals(ImportStep.PASSPHRASE_ENTRY, viewModel.securityState.value.importStep)
+    }
+
+    @Test
+    fun `onEvent ImportFirstWarningConfirmed THEN advancesToSecondConfirm`() = runTest {
+        // GIVEN — ViewModel with defaults
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — import first warning confirmed
+        viewModel.onEvent(SettingsEvent.ImportFirstWarningConfirmed)
+
+        // THEN — importStep advances to SECOND_CONFIRM
+        assertEquals(ImportStep.SECOND_CONFIRM, viewModel.securityState.value.importStep)
+    }
+
+    @Test
+    fun `onEvent ImportConfirmTextChanged THEN updatesText`() = runTest {
+        // GIVEN — ViewModel with defaults
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // WHEN — import confirm text changed
+        viewModel.onEvent(SettingsEvent.ImportConfirmTextChanged("OV"))
+
+        // THEN — importConfirmText is updated
+        assertEquals("OV", viewModel.securityState.value.importConfirmText)
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/pages/SecurityPageTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/pages/SecurityPageTest.kt
@@ -39,6 +39,8 @@ class SecurityPageTest {
         onEvent: (SettingsEvent) -> Unit = {},
         isSessionActive: Boolean = false,
         onLockNow: () -> Unit = {},
+        onExportClicked: () -> Unit = {},
+        onImportClicked: () -> Unit = {},
     ) {
         composeTestRule.setContent {
             CompositionLocalProvider(LocalDimensions provides Dimensions()) {
@@ -48,6 +50,8 @@ class SecurityPageTest {
                         onEvent = onEvent,
                         isSessionActive = isSessionActive,
                         onLockNow = onLockNow,
+                        onExportClicked = onExportClicked,
+                        onImportClicked = onImportClicked,
                     )
                 }
             }

--- a/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/models/BackupMetadataTest.kt
+++ b/shared/src/androidUnitTest/kotlin/com/veleda/cyclewise/domain/models/BackupMetadataTest.kt
@@ -1,0 +1,58 @@
+package com.veleda.cyclewise.domain.models
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BackupMetadataTest {
+
+    private val json = Json { encodeDefaults = true }
+
+    // region Serialization roundtrip
+
+    @Test
+    fun serializationRoundtrip_GIVEN_backupMetadata_THEN_decodedEqualsOriginal() {
+        // GIVEN — a fully populated BackupMetadata
+        val original = BackupMetadata(
+            appVersionName = "1.2.0",
+            appVersionCode = 12,
+            schemaVersion = 5,
+            exportDateUtc = "2026-03-19T14:30:22Z",
+        )
+
+        // WHEN — encoded to JSON and decoded back
+        val encoded = json.encodeToString(BackupMetadata.serializer(), original)
+        val decoded = json.decodeFromString(BackupMetadata.serializer(), encoded)
+
+        // THEN — the decoded instance equals the original
+        assertEquals(original, decoded)
+    }
+
+    // endregion
+
+    // region Deserialization from known JSON
+
+    @Test
+    fun deserialization_GIVEN_knownJsonString_THEN_producesExpectedValues() {
+        // GIVEN — a known JSON string
+        val knownJson = """
+            {
+                "appVersionName": "2.0.1",
+                "appVersionCode": 21,
+                "schemaVersion": 8,
+                "exportDateUtc": "2026-03-22T09:15:00Z"
+            }
+        """.trimIndent()
+
+        // WHEN — deserialized
+        val metadata = json.decodeFromString(BackupMetadata.serializer(), knownJson)
+
+        // THEN — each field matches the expected value
+        assertEquals("2.0.1", metadata.appVersionName)
+        assertEquals(21, metadata.appVersionCode)
+        assertEquals(8, metadata.schemaVersion)
+        assertEquals("2026-03-22T09:15:00Z", metadata.exportDateUtc)
+    }
+
+    // endregion
+}

--- a/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/BackupMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/veleda/cyclewise/domain/models/BackupMetadata.kt
@@ -1,0 +1,27 @@
+package com.veleda.cyclewise.domain.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Metadata embedded in a `.rwbackup` archive as `metadata.json`.
+ *
+ * Captures the app version, database schema version, and export timestamp so
+ * that the import flow can detect incompatibilities (e.g. a backup created with
+ * a newer schema than the current app supports) and display meaningful context
+ * in the preview dialog.
+ *
+ * Annotated with [@Serializable] because it is serialized to/from JSON inside
+ * the backup ZIP archive via `kotlinx.serialization`.
+ *
+ * @property appVersionName  Human-readable version string (e.g. `"1.2.0"`).
+ * @property appVersionCode  Numeric version code from the build (e.g. `12`).
+ * @property schemaVersion   Room database schema version at export time.
+ * @property exportDateUtc   ISO-8601 timestamp of the export (e.g. `"2026-03-19T14:30:22Z"`).
+ */
+@Serializable
+data class BackupMetadata(
+    val appVersionName: String,
+    val appVersionCode: Int,
+    val schemaVersion: Int,
+    val exportDateUtc: String,
+)


### PR DESCRIPTION

---
name: 🚀 Pull Request
about: Propose changes to the RhythmWise codebase

---

### Description

  Add a user-managed backup system that lets users export their encrypted database as a self-contained .rwbackup ZIP archive and import it on another device for device migration.

  Export is available from Settings > Security > Backup & Restore. The archive bundles the encrypted database, the Argon2id salt, and metadata (app version, schema version, export date).

  Import is available from three entry points:
  - Settings — with double confirmation (warns about overwriting existing data)
  - Unlock screen — with double confirmation
  - First-time setup screen — no confirmation needed (no existing data to lose)

  On import, the user must enter the original passphrase to verify the backup is decryptable before replacement. A rollback mechanism creates a backup of the current database before replacing, restoring it on any failure. Schema
   version checks prevent importing backups from newer app versions.

  Key components:
  - BackupManager (singleton-scoped) — handles ZIP creation/extraction, passphrase verification with imported salt via direct Argon2id, and safe database replacement with rollback
  - SaltStorage.setSalt() — allows restoring the backup's salt
  - PeriodDatabase.SCHEMA_VERSION — constant for metadata embedding without reflection
  - SessionManager.getOpenDatabase() — WAL checkpoint before export
  - BackupDialogs.kt — shared dialog composables for the multi-step import flow
  - ImportStep enum — state machine shared across Settings and Passphrase ViewModels
  - SAF (Storage Access Framework) for file picker integration


### Related Issue

Closes #115 

### Checklist

<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->