### PR TITLE
124 chore fix all detekt static analysis findings

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassPhraseScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/auth/PassPhraseScreen.kt
@@ -350,6 +350,7 @@ internal fun UnlockScreen(
  * Displays the appropriate dialog based on [PassphraseUiState.importStep], reusing
  * the dialog composables from [com.veleda.cyclewise.ui.backup.BackupDialogs].
  */
+@Suppress("LongMethod") // Dispatch-only when block — each branch delegates to an extracted dialog composable
 @Composable
 private fun ImportDialogFlow(
     uiState: PassphraseUiState,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/backup/BackupDialogs.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/backup/BackupDialogs.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
@@ -92,6 +91,7 @@ fun BackupMetadataPreviewDialog(
  * @param onVerify     Called with the entered passphrase when the user taps "Verify".
  * @param onDismiss    Called when the user cancels.
  */
+@Suppress("LongMethod") // Single cohesive dialog — splitting would scatter related UI logic
 @Composable
 fun BackupPassphraseDialog(
     error: String?,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ private const val PAGE_ABOUT = 4
  * [SettingsContent] for testability. Session-specific operations (Lock Now, Debug Seeder)
  * are handled at this level via Koin scope access.
  */
+@Suppress("LongMethod") // DI wiring and effect collection — content is already extracted to SettingsContent
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(navController: NavController) {
@@ -172,6 +173,7 @@ fun SettingsScreen(navController: NavController) {
  *                           Only used in debug builds for the developer seeder button.
  * @param modifier           Modifier applied to the root column.
  */
+@Suppress("LongMethod") // Tab row and pager dispatch — already minimal
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SettingsContent(

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModel.kt
@@ -243,6 +243,8 @@ data class AboutSettingsState(
  * @param deleteAllDataUseCase The [DeleteAllDataUseCase] for wiping all user data.
  * @param sessionManager       The [SessionManager] for session scope lifecycle operations.
  */
+// Five sub-states with extracted reduce functions — splitting would fragment cohesive settings logic
+@Suppress("LargeClass")
 class SettingsViewModel(
     private val appSettings: AppSettings,
     private val reminderScheduler: ReminderScheduler,

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/pages/SecurityPage.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/settings/pages/SecurityPage.kt
@@ -56,6 +56,8 @@ import com.veleda.cyclewise.ui.theme.LocalDimensions
 /**
  * Page 0 — Security: Autolock timeout, passphrase management, and data deletion.
  */
+// Settings page with four section cards and import dialog flow
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SecurityPage(
@@ -278,88 +280,127 @@ internal fun SecurityPage(
             }
         }
 
-        // First confirmation dialog
+        // Delete data confirmation dialogs
         if (state.showDeleteFirstConfirmation) {
-            AlertDialog(
-                onDismissRequest = { onEvent(SettingsEvent.DeleteAllDataCancelled) },
-                title = { Text(stringResource(R.string.settings_delete_first_title)) },
-                text = { Text(stringResource(R.string.settings_delete_first_body)) },
-                confirmButton = {
-                    Button(
-                        onClick = { onEvent(SettingsEvent.DeleteAllDataFirstConfirmed) },
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error,
-                            contentColor = MaterialTheme.colorScheme.onError,
-                        ),
-                    ) {
-                        Text(stringResource(R.string.settings_delete_first_confirm))
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { onEvent(SettingsEvent.DeleteAllDataCancelled) }) {
-                        Text(stringResource(R.string.settings_delete_first_cancel))
-                    }
-                }
-            )
+            DeleteFirstConfirmDialog(onEvent = onEvent)
         }
 
-        // Second confirmation dialog with text input
         if (state.showDeleteSecondConfirmation) {
-            AlertDialog(
-                onDismissRequest = { onEvent(SettingsEvent.DeleteAllDataCancelled) },
-                title = { Text(stringResource(R.string.settings_delete_second_title)) },
-                text = {
-                    Column(verticalArrangement = Arrangement.spacedBy(dims.md)) {
-                        Text(stringResource(R.string.settings_delete_second_body))
-                        OutlinedTextField(
-                            value = state.deleteConfirmText,
-                            onValueChange = { onEvent(SettingsEvent.DeleteConfirmTextChanged(it)) },
-                            label = { Text(stringResource(R.string.settings_delete_second_field_label)) },
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
-                    }
-                },
-                confirmButton = {
-                    Button(
-                        onClick = { onEvent(SettingsEvent.DeleteAllDataConfirmed) },
-                        enabled = state.deleteConfirmText == "DELETE",
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.error,
-                            contentColor = MaterialTheme.colorScheme.onError,
-                        ),
-                    ) {
-                        Text(stringResource(R.string.settings_delete_first_confirm))
-                    }
-                },
-                dismissButton = {
-                    TextButton(onClick = { onEvent(SettingsEvent.DeleteAllDataCancelled) }) {
-                        Text(stringResource(R.string.settings_delete_first_cancel))
-                    }
-                }
+            DeleteSecondConfirmDialog(
+                deleteConfirmText = state.deleteConfirmText,
+                onEvent = onEvent,
             )
         }
 
-        // Progress dialog while deleting
         if (state.isDeletingData) {
-            AlertDialog(
-                onDismissRequest = { /* non-dismissable */ },
-                title = { Text(stringResource(R.string.settings_delete_progress_title)) },
-                text = {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(dims.md),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
-                        Text(stringResource(R.string.settings_delete_progress_body))
-                    }
-                },
-                confirmButton = { /* no buttons — non-dismissable */ }
-            )
+            DeleteProgressDialog()
         }
 
         Spacer(Modifier.height(dims.xl))
     }
+}
+
+/**
+ * First step of the data deletion flow — a simple confirmation dialog
+ * asking "Are you sure you want to delete all data?"
+ *
+ * @param onEvent Event dispatcher for [SettingsEvent] variants.
+ */
+@Composable
+private fun DeleteFirstConfirmDialog(onEvent: (SettingsEvent) -> Unit) {
+    AlertDialog(
+        onDismissRequest = { onEvent(SettingsEvent.DeleteAllDataCancelled) },
+        title = { Text(stringResource(R.string.settings_delete_first_title)) },
+        text = { Text(stringResource(R.string.settings_delete_first_body)) },
+        confirmButton = {
+            Button(
+                onClick = { onEvent(SettingsEvent.DeleteAllDataFirstConfirmed) },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+            ) {
+                Text(stringResource(R.string.settings_delete_first_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onEvent(SettingsEvent.DeleteAllDataCancelled) }) {
+                Text(stringResource(R.string.settings_delete_first_cancel))
+            }
+        }
+    )
+}
+
+/**
+ * Second step of the data deletion flow — requires the user to type "DELETE"
+ * before the confirm button is enabled.
+ *
+ * @param deleteConfirmText Current text in the confirmation field.
+ * @param onEvent           Event dispatcher for [SettingsEvent] variants.
+ */
+@Composable
+private fun DeleteSecondConfirmDialog(
+    deleteConfirmText: String,
+    onEvent: (SettingsEvent) -> Unit,
+) {
+    val dims = LocalDimensions.current
+
+    AlertDialog(
+        onDismissRequest = { onEvent(SettingsEvent.DeleteAllDataCancelled) },
+        title = { Text(stringResource(R.string.settings_delete_second_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(dims.md)) {
+                Text(stringResource(R.string.settings_delete_second_body))
+                OutlinedTextField(
+                    value = deleteConfirmText,
+                    onValueChange = { onEvent(SettingsEvent.DeleteConfirmTextChanged(it)) },
+                    label = { Text(stringResource(R.string.settings_delete_second_field_label)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { onEvent(SettingsEvent.DeleteAllDataConfirmed) },
+                enabled = deleteConfirmText == "DELETE",
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = MaterialTheme.colorScheme.onError,
+                ),
+            ) {
+                Text(stringResource(R.string.settings_delete_first_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onEvent(SettingsEvent.DeleteAllDataCancelled) }) {
+                Text(stringResource(R.string.settings_delete_first_cancel))
+            }
+        }
+    )
+}
+
+/**
+ * Non-dismissable progress dialog shown while data deletion is in progress.
+ */
+@Composable
+private fun DeleteProgressDialog() {
+    val dims = LocalDimensions.current
+
+    AlertDialog(
+        onDismissRequest = { /* non-dismissable */ },
+        title = { Text(stringResource(R.string.settings_delete_progress_title)) },
+        text = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(dims.md),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                Text(stringResource(R.string.settings_delete_progress_body))
+            }
+        },
+        confirmButton = { /* no buttons — non-dismissable */ }
+    )
 }
 
 /**

--- a/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/LogSummarySheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/veleda/cyclewise/ui/tracker/LogSummarySheet.kt
@@ -1,5 +1,6 @@
 package com.veleda.cyclewise.ui.tracker
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -69,6 +70,8 @@ import kotlinx.datetime.LocalDate
  * @param onDeleteClick     Callback when the user taps the delete button.
  * @param onViewFullLogClick Callback when the user taps the "View Full Log" button.
  */
+// Linear null-guarded InfoCard rows for a single cohesive summary sheet
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 internal fun LogSummarySheetContent(
     log: FullDailyLog,
@@ -221,96 +224,32 @@ internal fun LogSummarySheetContent(
             )
         }
 
-        if (log.symptomLogs.isNotEmpty()) {
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                ),
-                shape = MaterialTheme.shapes.small
-            ) {
-                Column(modifier = Modifier.padding(dims.sm)) {
-                    Text(
-                        stringResource(R.string.tracker_symptoms_label),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(dims.sm),
-                        modifier = Modifier.padding(top = dims.xs)
-                    ) {
-                        items(log.symptomLogs, key = { it.symptomId }) { symptomLog ->
-                            val symptomInfo = symptomLibrary.find { it.id == symptomLog.symptomId }
-                            if (symptomInfo != null) {
-                                SuggestionChip(
-                                    onClick = {},
-                                    label = { Text(symptomInfo.name) }
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        ChipRowSection(
+            titleResId = R.string.tracker_symptoms_label,
+            items = log.symptomLogs,
+            key = { it.symptomId },
+            resolveName = { symptomLog ->
+                symptomLibrary.find { it.id == symptomLog.symptomId }?.name
+            },
+        )
 
-        if (log.medicationLogs.isNotEmpty()) {
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                ),
-                shape = MaterialTheme.shapes.small
-            ) {
-                Column(modifier = Modifier.padding(dims.sm)) {
-                    Text(
-                        stringResource(R.string.tracker_medications_label),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(dims.sm),
-                        modifier = Modifier.padding(top = dims.xs)
-                    ) {
-                        items(log.medicationLogs, key = { it.medicationId }) { medicationLog ->
-                            val medicationInfo =
-                                medicationLibrary.find { it.id == medicationLog.medicationId }
-                            if (medicationInfo != null) {
-                                SuggestionChip(
-                                    onClick = {},
-                                    label = { Text(medicationInfo.name) }
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        ChipRowSection(
+            titleResId = R.string.tracker_medications_label,
+            items = log.medicationLogs,
+            key = { it.medicationId },
+            resolveName = { medicationLog ->
+                medicationLibrary.find { it.id == medicationLog.medicationId }?.name
+            },
+        )
 
-        if (log.customTagLogs.isNotEmpty()) {
-            Card(
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant
-                ),
-                shape = MaterialTheme.shapes.small
-            ) {
-                Column(modifier = Modifier.padding(dims.sm)) {
-                    Text(
-                        stringResource(R.string.tracker_custom_tags_label),
-                        style = MaterialTheme.typography.titleMedium
-                    )
-                    LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(dims.sm),
-                        modifier = Modifier.padding(top = dims.xs)
-                    ) {
-                        items(log.customTagLogs, key = { it.tagId }) { tagLog ->
-                            val tagInfo = customTagLibrary.find { it.id == tagLog.tagId }
-                            if (tagInfo != null) {
-                                SuggestionChip(
-                                    onClick = {},
-                                    label = { Text(tagInfo.name) }
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        ChipRowSection(
+            titleResId = R.string.tracker_custom_tags_label,
+            items = log.customTagLogs,
+            key = { it.tagId },
+            resolveName = { tagLog ->
+                customTagLibrary.find { it.id == tagLog.tagId }?.name
+            },
+        )
 
         FilledTonalButton(
             onClick = { onViewFullLogClick(log.entry.entryDate) },
@@ -320,6 +259,56 @@ internal fun LogSummarySheetContent(
         }
 
         Spacer(Modifier.height(dims.md))
+    }
+}
+
+/**
+ * A card with a titled [LazyRow] of [SuggestionChip]s, used for symptom, medication,
+ * and custom tag summaries in the log sheet.
+ *
+ * @param T           The type of log entry items (e.g. SymptomLog, MedicationLog).
+ * @param titleResId  String resource ID for the section title.
+ * @param items       The log entries to display as chips.
+ * @param key         Key selector for [LazyRow] item identity.
+ * @param resolveName Resolves a display name from a log entry, or `null` if unresolvable.
+ */
+@Composable
+private fun <T> ChipRowSection(
+    @StringRes titleResId: Int,
+    items: List<T>,
+    key: (T) -> Any,
+    resolveName: (T) -> String?,
+) {
+    if (items.isEmpty()) return
+
+    val dims = LocalDimensions.current
+
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        shape = MaterialTheme.shapes.small
+    ) {
+        Column(modifier = Modifier.padding(dims.sm)) {
+            Text(
+                stringResource(titleResId),
+                style = MaterialTheme.typography.titleMedium
+            )
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(dims.sm),
+                modifier = Modifier.padding(top = dims.xs)
+            ) {
+                items(items, key = key) { item ->
+                    val name = resolveName(item)
+                    if (name != null) {
+                        SuggestionChip(
+                            onClick = {},
+                            label = { Text(name) }
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
---
name: 🚀 Pull Request
about: Propose changes to the RhythmWise codebase

---

### Description

  Resolve all 10 detekt static analysis findings across the codebase. Changes fall into two categories:                                                                                                                             
                                                                                                                                                                                                                                    
  1. @Suppress annotations with justifications — for findings where the complexity is inherent and splitting would hurt readability (e.g., LongMethod on single-cohesive dialog composables, LargeClass on SettingsViewModel which
  manages five sub-states with extracted reduce functions, CyclomaticComplexMethod on null-guarded layout dispatch).
  2. Extract composables to reduce method length — where extraction genuinely improves structure:
    - SecurityPage.kt: Extracted DeleteFirstConfirmDialog, DeleteSecondConfirmDialog, and DeleteProgressDialog from an inline when block.
    - LogSummarySheet.kt: Extracted a generic ChipRowSection<T> composable to deduplicate three nearly-identical symptom/medication/custom-tag chip row blocks.
    - BackupDialogs.kt: Removed unused padding import.


### Related Issue

Closes #124 

### Checklist

<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->