### PR TITLE
chore(build): target Android 16, lock portrait, release v1.1.1 (#163)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Java 21 is required by Robolectric's Android SDK 36 runtime, which the
+      # unit tests resolve from the app's targetSdk. This is the JDK that runs
+      # Gradle and the tests; the compiled bytecode target stays at 11
+      # (see compileOptions / jvmTarget in composeApp/build.gradle.kts).
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -99,8 +99,8 @@ android {
         applicationId = "com.politebyte.rhythmwise"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 5
-        versionName = "1.1.0"
+        versionCode = 6
+        versionName = "1.1.1"
         testInstrumentationRunner = "com.veleda.cyclewise.CustomTestRunner"
     }
     // This is the standard, safe way to handle duplicate text files

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:theme="@style/Theme.RhythmWise.Splash">
         <activity
             android:exported="true"
-            android:name=".MainActivity">
+            android:name=".MainActivity"
+            android:screenOrientation="userPortrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/veleda/cyclewise/ui/settings/SettingsViewModelTest.kt
@@ -777,9 +777,14 @@ class SettingsViewModelTest {
             viewModel.onEvent(SettingsEvent.DeleteAllDataConfirmed)
             advanceUntilIdle()
 
-            // THEN — use case was invoked and DataDeleted effect was emitted
-            coVerify(exactly = 1) { mockDeleteAllDataUseCase() }
+            // THEN — the effect is awaited BEFORE verifying the use case.
+            // The deletion runs inside withContext(Dispatchers.IO), a real thread
+            // pool that advanceUntilIdle() cannot wait for, so there is no
+            // happens-before edge at this point. The emit is sequenced after that
+            // block returns, so awaiting the item is what proves the use case ran.
+            // Verifying first races the IO thread and fails under CI load.
             assertEquals(SettingsEffect.DataDeleted, awaitItem())
+            coVerify(exactly = 1) { mockDeleteAllDataUseCase() }
         }
 
         // THEN — session was closed and confirmation state is reset

--- a/docs/DeveloperOnboarding.md
+++ b/docs/DeveloperOnboarding.md
@@ -498,10 +498,23 @@ plugins {
 
 ```
 minSdk     = 26     (Android 8.0 Oreo)
-targetSdk  = 35     (Android 15)
-compileSdk = 35
+targetSdk  = 36     (Android 16)
+compileSdk = 36
 JVM target = 11
 ```
+
+Google Play requires the target API level to stay within one year of the latest
+Android release, so `targetSdk` is bumped on Play's schedule rather than on ours.
+Targeting Android 16 also makes three platform behaviors mandatory rather than
+optional; all three were already satisfied when the app moved to 36:
+
+- **Edge-to-edge cannot be opted out of.** `MainActivity` calls `enableEdgeToEdge()`
+  and each screen owns its insets (see §Window Insets in `CLAUDE.md`).
+- **Orientation and resizability restrictions are ignored on large screens.** The
+  manifest declares no `screenOrientation` or `resizableActivity`, so the app is
+  free to rotate and resize.
+- **Predictive back is on by default.** `android:enableOnBackInvokedCallback="true"`
+  is already set in the manifest.
 
 ### Room Schema Export
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-## v1.1.0
+## v1.1.1
 
 **RhythmWise** is a privacy-first menstrual cycle tracker for Android. All of your data stays on your device — encrypted, offline, and fully under your control.
 
@@ -6,18 +6,12 @@
 
 A comprehensive cycle tracking app built with one guiding principle: **your data belongs to you**. There are no accounts, no cloud sync, no analytics, and no internet connection — ever. Your database is encrypted with AES-256-GCM (SQLCipher) behind a passphrase that only you know.
 
-### What's New in 1.1.0
+### What's New in 1.1.1
 
-A new app icon, plus a big round of beta feedback improvements: clearer mood, energy, and libido selectors, a cycle status banner on the home screen, one-tap period start that fills in your usual duration, predictions from day one, an easier to read calendar, a visual color picker, new auto-lock options, and optional sound effects for accessibility (off by default). Also fixes the follicular phase display and startup errors.
+A small fix-up release. The calendar no longer gets squashed when your phone turns sideways, and RhythmWise is updated to run against the latest Android release.
 
-This update is built almost entirely from your beta feedback. Thanks for all of it, keep it coming.
-
-- **A new look**: RhythmWise has a proper icon now, based on the moon cycle artwork. On Android 13+ it also adapts to your wallpaper colors if you use themed icons.
-- **Faster logging**: Mood, energy, and libido use descriptive icons (faces, bolts, hearts), only your current pick stays highlighted, and a clear "3/5" style readout shows what you logged. The note editor capitalizes sentences and continues bullet lists for you, and a banner on the home screen shows where you are in your cycle at a glance.
-- **Smarter tracking**: Setup asks for your typical cycle and period length, so predictions work from your very first day. Starting a period with one tap fills in your usual duration, with undo. The calendar is easier to scan, with visible daily scores and a stronger ring around today, and future dates can no longer be logged by accident.
-- **Optional sound effects**: A new Sound section in Settings under Notifications adds quiet audio feedback for taps, swipes, and actions. It is off by default and meant mainly as an accessibility aid for anyone who finds the screen hard to see, with its own volume slider that previews the level as you set it.
-- **Settings and polish**: Phase and heatmap colors have a real visual color picker. Auto-lock gains Immediately and Never options. Insight cards are calmer, learn articles collapse out of the way, and the tutorial has a visible skip button, a step indicator, and can be replayed.
-- **Fixes**: An ongoing period no longer hides the follicular phase, and startup problems now show an error instead of a blank screen.
+- **The calendar stays readable**: Turning your phone sideways used to squeeze the calendar until the dates piled on top of each other. RhythmWise now stays upright, so the month view is always readable. On tablets, where there is room for it, the app still rotates freely.
+- **Ready for Android 16**: Updated under the hood to build against the newest Android version. Nothing changes in how you use the app, it just keeps RhythmWise current and eligible for future updates.
 
 ### Features
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 agp = "8.11.0"
-android-compileSdk = "35"
+android-compileSdk = "36"
 android-minSdk = "26"
-android-targetSdk = "35"
+android-targetSdk = "36"
 androidx-activity = "1.10.1"
 androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"


### PR DESCRIPTION
* chore(build): target Android 16 (API 36)

Google Play requires the target API level to stay within one year of the latest Android release; targeting 35 blocks app updates after Aug 30, 2026.

Bumps compileSdk and targetSdk to 36. The three Android 16 behaviors that become mandatory when targeting 36 were already satisfied: edge-to-edge is enabled in MainActivity with per-screen insets and no opt-out flag, the manifest declares no orientation or resizability restrictions, and predictive back is already opted in.

Refs #161



Claude-Session: https://claude.ai/code/session_01YKxC5eWrxFrZii2ySE6BKa

* fix(ci): run tests on Java 21 for the Android 16 Robolectric runtime

Robolectric resolves its Android SDK from the app's targetSdk. With targetSdk 36 it loads the Android 16 sandbox, which requires Java 21:

    UnsupportedOperationException: Failed to create a Robolectric sandbox:
    Android SDK 36 requires Java 21 (have Java 17)

Every Robolectric test class failed at initialization on CI (68 classes) while passing locally on Java 23. Bumps the CI JDK from 17 to 21.

This is the JDK that runs Gradle and the tests only; the compiled bytecode target stays at 11 and no toolchain is pinned.

Refs #161



Claude-Session: https://claude.ai/code/session_01YKxC5eWrxFrZii2ySE6BKa

* test(settings): await the effect before verifying the delete use case

The DeleteAllDataConfirmed test verified the use case mock before awaiting the DataDeleted effect. The deletion runs inside withContext(Dispatchers.IO), a real thread pool that advanceUntilIdle() cannot wait for, so the coVerify had no happens-before edge and raced the IO thread. It failed on a loaded CI runner while passing locally.

The emit is sequenced after the IO block returns, so awaiting the item first establishes the ordering the verification needs.

Pre-existing race, unrelated to the SDK bump; it surfaced once the Robolectric fix let the full suite run again.

Refs #161



Claude-Session: https://claude.ai/code/session_01YKxC5eWrxFrZii2ySE6BKa

* fix(ui): lock the app to portrait to stop the calendar collapsing

In landscape on a phone the calendar had roughly 411dp of height to fit six week rows. Nothing shrank or scrolled, so the rows overlapped and the date numbers became unreadable, and the today ring stretched into a pill.

Verified on an API 36 Pixel 8 emulator: the lock is honored on phones. On displays at or above 600dp Android 16 ignores screenOrientation, but the calendar renders correctly there anyway because it has the vertical space, so the case the lock cannot cover is the case that was never broken.

Pre-existing since before the targetSdk bump; surfaced during QA of #161.

Refs #161



Claude-Session: https://claude.ai/code/session_01YKxC5eWrxFrZii2ySE6BKa

* chore(release): bump version to 1.1.1

versionCode 6. Covers the Android 16 target bump and the portrait lock. Release notes rewritten for 1.1.1; the headline paragraph doubles as the Play Store "What's new" text (189 characters, well under the 500 limit).

Refs #161



Claude-Session: https://claude.ai/code/session_01YKxC5eWrxFrZii2ySE6BKa

* fix(ui): use userPortrait and trim the release headline

userPortrait keeps the app upright but additionally allows the 180-degree flip when the user has auto-rotate enabled, which helps anyone using a dock, mount, or inverted grip. It still never allows landscape, so the calendar fix is unchanged. With rotation locked it behaves identically to portrait.

Refs #161



Claude-Session: https://claude.ai/code/session_01YKxC5eWrxFrZii2ySE6BKa

---------

---
name: 🚀 Pull Request
about: Propose changes to the RhythmWise codebase

---

### Description

<!-- A clear and concise description of the changes. -->

### Related Issue

<!-- 
Link to the issue that this PR addresses. 
For example: "Closes #23" or "Fixes #12". This will automatically close the issue when the PR is merged.
-->

### Checklist


<!-- 
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [**CONTRIBUTING.md**](CONTRIBUTING.md) document.
- [x] My commit messages follow the [Conventional Commits](docs/GIT_COMMIT_GUIDELINES.md) specification.
- [x] I have signed off on my commits using the DCO (`git commit -s`).
- [x] I have added or updated unit/E2E tests to cover my changes.
- [x] I have run the full test suite locally (`./gradlew test`) and all tests pass.

### Additional Context

<!-- Add any other context, screenshots, or screen recordings about the pull request here. -->
